### PR TITLE
(sramp-48) Support for running in JBoss AS 7 (take 2)

### DIFF
--- a/s-ramp-atom/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/s-ramp-atom/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -10,6 +10,9 @@
 			<module name="org.jboss.resteasy.resteasy-jackson-provider" slot="main" />
 			<module name="org.jboss.resteasy.resteasy-jettison-provider" slot="main" />
 			<module name="org.jboss.resteasy.resteasy-yaml-provider" slot="main" />
+			<module name="javax.ws.rs.api" slot="main" />
+			<module name="org.jboss.as.jaxrs" slot="main" />
+			<module name="org.codehaus.jackson.jackson-jaxrs" slot="main" />
 		</exclusions>
 	</deployment>
 </jboss-deployment-structure>

--- a/s-ramp-client/src/main/java/org/overlord/sramp/client/ClientRequest.java
+++ b/s-ramp-client/src/main/java/org/overlord/sramp/client/ClientRequest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2012 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.overlord.sramp.client;
+
+import javax.ws.rs.core.UriBuilder;
+
+import org.jboss.resteasy.client.ClientExecutor;
+import org.jboss.resteasy.plugins.providers.RegisterBuiltin;
+import org.jboss.resteasy.specimpl.UriBuilderImpl;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
+
+/**
+ * Extends the RESTEasy {@link org.jboss.resteasy.client.ClientRequest} class in order to provide a
+ * {@link ClientExecutor} and {@link ResteasyProviderFactory} without requiring clients to pass them in.
+ * 
+ * @author eric.wittmann@redhat.com
+ */
+public class ClientRequest extends org.jboss.resteasy.client.ClientRequest {
+	
+	private static final ResteasyProviderFactory providerFactory = new ResteasyProviderFactory();
+	static {
+		RegisterBuiltin.register(providerFactory);
+	}
+
+	/**
+	 * Constructor.
+	 * @param uriTemplate
+	 */
+	public ClientRequest(String uriTemplate) {
+		super(getBuilder(uriTemplate), getDefaultExecutor(), providerFactory);
+	}
+
+	/**
+	 * Creates a {@link UriBuilder} for the given URI template.
+	 * @param uriTemplate
+	 */
+	private static UriBuilder getBuilder(String uriTemplate) {
+		return new UriBuilderImpl().uriTemplate(uriTemplate);
+	}
+
+}

--- a/s-ramp-client/src/main/java/org/overlord/sramp/client/SrampAtomApiClient.java
+++ b/s-ramp-client/src/main/java/org/overlord/sramp/client/SrampAtomApiClient.java
@@ -20,9 +20,7 @@ import java.net.URL;
 
 import javax.ws.rs.core.MediaType;
 
-import org.jboss.resteasy.client.ClientRequest;
 import org.jboss.resteasy.client.ClientResponse;
-import org.jboss.resteasy.client.core.executors.ApacheHttpClient4Executor;
 import org.jboss.resteasy.plugins.providers.atom.Entry;
 import org.jboss.resteasy.plugins.providers.atom.Feed;
 import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataOutput;
@@ -57,16 +55,10 @@ public class SrampAtomApiClient {
 	 * @throws Exception 
 	 */
 	public Entry getFullArtifactEntry(String artifactModel, String artifactType, String artifactUuid) throws Exception {
-		ClassLoader oldCtxCL = Thread.currentThread().getContextClassLoader();
-		Thread.currentThread().setContextClassLoader(ApacheHttpClient4Executor.class.getClassLoader());
-		try {
-			String atomUrl = String.format("%1$s/%2$s/%3$s/%4$s", this.endpoint, artifactModel, artifactType, artifactUuid);
-			ClientRequest request = new ClientRequest(atomUrl);
-			ClientResponse<Entry> response = request.get(Entry.class);
-			return response.getEntity();
-		} finally {
-			Thread.currentThread().setContextClassLoader(oldCtxCL);
-		}
+		String atomUrl = String.format("%1$s/%2$s/%3$s/%4$s", this.endpoint, artifactModel, artifactType, artifactUuid);
+		ClientRequest request = new ClientRequest(atomUrl);
+		ClientResponse<Entry> response = request.get(Entry.class);
+		return response.getEntity();
 	}
 	
 	/**
@@ -108,20 +100,14 @@ public class SrampAtomApiClient {
 	 * @throws Exception
 	 */
 	public Entry uploadArtifact(String artifactModel, String artifactType, InputStream content, String artifactFileName) throws Exception {
-		ClassLoader oldCtxCL = Thread.currentThread().getContextClassLoader();
-		Thread.currentThread().setContextClassLoader(ApacheHttpClient4Executor.class.getClassLoader());
-		try {
-			String atomUrl = String.format("%1$s/%2$s/%3$s", this.endpoint, artifactModel, artifactType);
-			ClientRequest request = new ClientRequest(atomUrl);
-			if (artifactFileName != null)
-				request.header("Slug", artifactFileName);
-			request.body(MediaType.APPLICATION_XML, content);
+		String atomUrl = String.format("%1$s/%2$s/%3$s", this.endpoint, artifactModel, artifactType);
+		ClientRequest request = new ClientRequest(atomUrl);
+		if (artifactFileName != null)
+			request.header("Slug", artifactFileName);
+		request.body(MediaType.APPLICATION_XML, content);
 
-			ClientResponse<Entry> response = request.post(Entry.class);
-			return response.getEntity();
-		} finally {
-			Thread.currentThread().setContextClassLoader(oldCtxCL);
-		}
+		ClientResponse<Entry> response = request.post(Entry.class);
+		return response.getEntity();
 	}
 	
 	/**
@@ -144,24 +130,19 @@ public class SrampAtomApiClient {
 		// Remove the leading /s-ramp/ prior to POSTing to the atom endpoint
 		if (xpath.startsWith("/s-ramp/"))
 			xpath = xpath.substring(8);
-		ClassLoader oldCtxCL = Thread.currentThread().getContextClassLoader();
-		Thread.currentThread().setContextClassLoader(ApacheHttpClient4Executor.class.getClassLoader());
-		try {
-			String atomUrl = this.endpoint;
-			ClientRequest request = new ClientRequest(atomUrl);
-			MultipartFormDataOutput formData = new MultipartFormDataOutput();
-			formData.addFormData("query", srampQuery, MediaType.TEXT_PLAIN_TYPE);
-			formData.addFormData("page", String.valueOf(page), MediaType.TEXT_PLAIN_TYPE);
-			formData.addFormData("pageSize", String.valueOf(pageSize), MediaType.TEXT_PLAIN_TYPE);
-			formData.addFormData("orderBy", orderBy, MediaType.TEXT_PLAIN_TYPE);
-			formData.addFormData("ascending", String.valueOf(ascending), MediaType.TEXT_PLAIN_TYPE);
-			
-			request.body(MediaType.MULTIPART_FORM_DATA_TYPE, formData);
-			ClientResponse<Feed> response = request.post(Feed.class);
-			return response.getEntity();
-		} finally {
-			Thread.currentThread().setContextClassLoader(oldCtxCL);
-		}
+		String atomUrl = this.endpoint;
+		
+		ClientRequest request = new ClientRequest(atomUrl);
+		MultipartFormDataOutput formData = new MultipartFormDataOutput();
+		formData.addFormData("query", srampQuery, MediaType.TEXT_PLAIN_TYPE);
+		formData.addFormData("page", String.valueOf(page), MediaType.TEXT_PLAIN_TYPE);
+		formData.addFormData("pageSize", String.valueOf(pageSize), MediaType.TEXT_PLAIN_TYPE);
+		formData.addFormData("orderBy", orderBy, MediaType.TEXT_PLAIN_TYPE);
+		formData.addFormData("ascending", String.valueOf(ascending), MediaType.TEXT_PLAIN_TYPE);
+		
+		request.body(MediaType.MULTIPART_FORM_DATA_TYPE, formData);
+		ClientResponse<Feed> response = request.post(Feed.class);
+		return response.getEntity();
 	}
 	
 }


### PR DESCRIPTION
Updates to the atom api client to get it working in JBoss AS 7.

The previous checkin solved the problems with using a newer version of resteasy in JBoss to expose the s-ramp Atom API.  This checkin solves an issue when both the s-ramp and s-ramp-ui WARs are deployed to JBoss.
