### PR TITLE
(sramp-41) Remove "any-outgoing-relationship" boolean in RelationshipPath

### DIFF
--- a/s-ramp-core/src/main/java/org/overlord/sramp/query/xpath/ast/RelationshipPath.java
+++ b/s-ramp-core/src/main/java/org/overlord/sramp/query/xpath/ast/RelationshipPath.java
@@ -24,7 +24,6 @@ import org.overlord.sramp.query.xpath.visitors.XPathVisitor;
  */
 public class RelationshipPath extends AbstractXPathNode {
 
-	private boolean anyOutgoingRelationship;
 	private String relationshipType;
 
 	/**
@@ -39,25 +38,7 @@ public class RelationshipPath extends AbstractXPathNode {
 	 */
 	public RelationshipPath(String relationshipType) {
 		this();
-		if ("outgoing".equals(relationshipType)) {
-			setAnyOutgoingRelationship(true);
-		} else {
-			setRelationshipType(relationshipType);
-		}
-	}
-
-	/**
-	 * @return the anyOutgoingRelationship
-	 */
-	public boolean isAnyOutgoingRelationship() {
-		return anyOutgoingRelationship;
-	}
-
-	/**
-	 * @param anyOutgoingRelationship the anyOutgoingRelationship to set
-	 */
-	public void setAnyOutgoingRelationship(boolean anyOutgoingRelationship) {
-		this.anyOutgoingRelationship = anyOutgoingRelationship;
+		setRelationshipType(relationshipType);
 	}
 
 	/**

--- a/s-ramp-core/src/main/java/org/overlord/sramp/query/xpath/visitors/XPathSerializationVisitor.java
+++ b/s-ramp-core/src/main/java/org/overlord/sramp/query/xpath/visitors/XPathSerializationVisitor.java
@@ -247,10 +247,7 @@ public class XPathSerializationVisitor implements XPathVisitor {
 	 */
 	@Override
 	public void visit(RelationshipPath node) {
-		if (node.isAnyOutgoingRelationship())
-			this.builder.append("outgoing");
-		else
-			this.builder.append(node.getRelationshipType());
+		this.builder.append(node.getRelationshipType());
 	}
 
 	/**

--- a/s-ramp-core/src/test/java/org/overlord/sramp/query/xpath/XPathParserTest.java
+++ b/s-ramp-core/src/test/java/org/overlord/sramp/query/xpath/XPathParserTest.java
@@ -46,7 +46,7 @@ import org.overlord.sramp.query.xpath.visitors.XPathSerializationVisitor;
 public class XPathParserTest {
 	
 	@Test
-	public void testArtifactSet() throws Exception {
+	public void testXPathParser() throws Exception {
 		Collection<Properties> testCases = getTestCases();
 		
 		XPathParser parser = new XPathParser();


### PR DESCRIPTION
Removed the 'any outgoing relationship' attribute from the xpath relationship path parsing.  I mis-read the grammar when I implemented that.
