### PR TITLE
(sramp-49) Improved s-ramp error handling (Atom layer)

### DIFF
--- a/s-ramp-atom/pom.xml
+++ b/s-ramp-atom/pom.xml
@@ -57,7 +57,7 @@
 			<version>${org.jboss.resteasy.version}</version>
 			<scope>test</scope>
 		</dependency>
-		
+
 		<!-- S-RAMP project dependencies -->
 		<dependency>
 			<groupId>org.overlord.sramp</groupId>
@@ -74,22 +74,22 @@
 			<artifactId>s-ramp-repository</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-		
-		<!-- Provided libraries -->
-        <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
-            <version>2.5</version>
-            <scope>provided</scope>
-        </dependency>
 
-        <!-- Common libraries -->
+		<!-- Provided libraries -->
 		<dependency>
-			<groupId>org.apache.commons</groupId>
+			<groupId>javax.servlet</groupId>
+			<artifactId>servlet-api</artifactId>
+			<scope>provided</scope>
+		</dependency>
+
+		<!-- Common libraries -->
+		<dependency>
+			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
 		</dependency>
 
-		<!-- S-RAMP Provider (only JCR for now: runtime scope for Tomcat deployment and unit testing) -->
+		<!-- S-RAMP Provider (only JCR for now: runtime scope for Tomcat deployment 
+			and unit testing) -->
 		<dependency>
 			<groupId>org.overlord.sramp</groupId>
 			<artifactId>s-ramp-repository-jcr</artifactId>
@@ -125,5 +125,17 @@
 			<scope>runtime</scope>
 		</dependency>
 	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-war-plugin</artifactId>
+				<configuration>
+					<attachClasses>true</attachClasses>
+					<classesClassifier>classes</classesClassifier>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 
 </project>

--- a/s-ramp-atom/src/main/java/org/overlord/sramp/atom/err/SrampAtomException.java
+++ b/s-ramp-atom/src/main/java/org/overlord/sramp/atom/err/SrampAtomException.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2012 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.overlord.sramp.atom.err;
+
+/**
+ * The exception thrown by the Atom layer whenever something goes horribly, horribly wrong.
+ *
+ * @author eric.wittmann@redhat.com
+ */
+public class SrampAtomException extends Exception {
+
+	private static final long serialVersionUID = -4954468657023096910L;
+
+	/**
+	 * Constructor.
+	 */
+	public SrampAtomException() {
+	}
+
+	/**
+	 * Constructor.
+	 * @param message
+	 */
+	public SrampAtomException(String message) {
+		super(message);
+	}
+
+	/**
+	 * Constructor.
+	 * @param message
+	 * @param cause
+	 */
+	public SrampAtomException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	/**
+	 * Constructor.
+	 * @param cause
+	 */
+	public SrampAtomException(Throwable cause) {
+		super(cause);
+	}
+
+}

--- a/s-ramp-atom/src/main/java/org/overlord/sramp/atom/err/SrampAtomExceptionMapper.java
+++ b/s-ramp-atom/src/main/java/org/overlord/sramp/atom/err/SrampAtomExceptionMapper.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2012 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.overlord.sramp.atom.err;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.ResponseBuilder;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.MessageBodyWriter;
+import javax.ws.rs.ext.Provider;
+
+import org.jboss.resteasy.annotations.interception.ServerInterceptor;
+
+/**
+ * An exception handler for sramp atom exceptions.
+ *
+ * @author eric.wittmann@redhat.com
+ */
+@Provider
+@ServerInterceptor
+public class SrampAtomExceptionMapper implements ExceptionMapper<SrampAtomException>, MessageBodyWriter<SrampAtomException> {
+	
+	/**
+	 * Constructor.
+	 */
+	public SrampAtomExceptionMapper() {
+	}
+
+	/**
+	 * @see javax.ws.rs.ext.ExceptionMapper#toResponse(java.lang.Throwable)
+	 */
+	@Override
+	public Response toResponse(SrampAtomException exception) {
+		ResponseBuilder builder = Response.status(500);
+		builder.header("S-RAMP-Exception-Message", getRootCause(exception).getMessage());
+		builder.type("application/stacktrace");
+		builder.entity(exception);
+		return builder.build();
+	}
+	
+	/**
+	 * @see javax.ws.rs.ext.MessageBodyWriter#isWriteable(java.lang.Class, java.lang.reflect.Type, java.lang.annotation.Annotation[], javax.ws.rs.core.MediaType)
+	 */
+	@Override
+	public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+		return type == SrampAtomException.class;
+	}
+
+	/**
+	 * @see javax.ws.rs.ext.MessageBodyWriter#getSize(java.lang.Object, java.lang.Class, java.lang.reflect.Type, java.lang.annotation.Annotation[], javax.ws.rs.core.MediaType)
+	 */
+	@Override
+	public long getSize(SrampAtomException t, Class<?> type, Type genericType, Annotation[] annotations,
+			MediaType mediaType) {
+		return -1l;
+	}
+
+	/**
+	 * @see javax.ws.rs.ext.MessageBodyWriter#writeTo(java.lang.Object, java.lang.Class, java.lang.reflect.Type, java.lang.annotation.Annotation[], javax.ws.rs.core.MediaType, javax.ws.rs.core.MultivaluedMap, java.io.OutputStream)
+	 */
+	@Override
+	public void writeTo(SrampAtomException t, Class<?> type, Type genericType, Annotation[] annotations,
+			MediaType mediaType, MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream)
+			throws IOException, WebApplicationException {
+		String stack = getRootStackTrace(t);
+		entityStream.write(stack.getBytes("UTF-8"));
+		entityStream.flush();
+	}
+
+	/**
+	 * Gets the root stack trace as a string.
+	 * @param t
+	 */
+	public static String getRootStackTrace(Throwable t) {
+		StringWriter sw = new StringWriter();
+		PrintWriter writer = new PrintWriter(sw);
+		getRootCause(t).printStackTrace(writer);
+		return sw.getBuffer().toString();
+	}
+
+	/**
+	 * Gets the root exception from the given {@link Throwable}.
+	 * @param t
+	 */
+	public static Throwable getRootCause(Throwable t) {
+		Throwable root = t;
+		while (root.getCause() != null && root.getCause() != root)
+			root = root.getCause();
+		return root;
+	}
+
+}

--- a/s-ramp-atom/src/main/java/org/overlord/sramp/atom/services/SRAMPApplication.java
+++ b/s-ramp-atom/src/main/java/org/overlord/sramp/atom/services/SRAMPApplication.java
@@ -20,29 +20,39 @@ import java.util.Set;
 
 import javax.ws.rs.core.Application;
 
-public class SRAMPApplication extends Application
-{
-   private Set<Object> singletons = new HashSet<Object>();
-   private Set<Class<?>> empty = new HashSet<Class<?>>();
+import org.overlord.sramp.atom.err.SrampAtomExceptionMapper;
 
-   public SRAMPApplication()
-   {
-      singletons.add(new EntryResource());
-      singletons.add(new ServiceDocumentResource());
-      singletons.add(new FeedResource());
-      singletons.add(new XsdDocumentResource());
-      singletons.add(new AdHocQueryResource());
-   }
+/**
+ * The SRAMP RESTEasy application.  This is essentially the main entry point into a 
+ * RESTEasy application - it provides the resource implementaiton as well as any other
+ * providers (mappers, etc).
+ */
+public class SRAMPApplication extends Application {
+	
+	private Set<Object> singletons = new HashSet<Object>();
+	private Set<Class<?>> classes = new HashSet<Class<?>>();
 
-   @Override
-   public Set<Class<?>> getClasses()
-   {
-      return empty;
-   }
+	/**
+	 * Constructor.
+	 */
+	public SRAMPApplication() {
+		singletons.add(new EntryResource());
+		singletons.add(new ServiceDocumentResource());
+		singletons.add(new FeedResource());
+		singletons.add(new XsdDocumentResource());
+		singletons.add(new XmlDocumentResource());
+		singletons.add(new AdHocQueryResource());
+		
+		classes.add(SrampAtomExceptionMapper.class);
+	}
 
-   @Override
-   public Set<Object> getSingletons()
-   {
-      return singletons;
-   }
+	@Override
+	public Set<Class<?>> getClasses() {
+		return classes;
+	}
+
+	@Override
+	public Set<Object> getSingletons() {
+		return singletons;
+	}
 }

--- a/s-ramp-atom/src/main/java/org/overlord/sramp/atom/services/XmlDocumentResource.java
+++ b/s-ramp-atom/src/main/java/org/overlord/sramp/atom/services/XmlDocumentResource.java
@@ -25,6 +25,7 @@ import javax.ws.rs.Produces;
 import org.jboss.resteasy.plugins.providers.atom.Entry;
 import org.overlord.sramp.ArtifactType;
 import org.overlord.sramp.atom.MediaType;
+import org.overlord.sramp.atom.err.SrampAtomException;
 
 /**
  * Implements the XmlDocument S-RAMP Atom API resource.  This provides the mechanism for adding, deleting,
@@ -33,8 +34,8 @@ import org.overlord.sramp.atom.MediaType;
  * @author eric.wittmann@redhat.com
  */
 @Path("/s-ramp/core/XmlDocument")
-public class XmlDocumentResource extends AbstractDocumentResource
-{
+public class XmlDocumentResource extends AbstractDocumentResource {
+
 	/**
 	 * Default constructor.
 	 */
@@ -49,8 +50,8 @@ public class XmlDocumentResource extends AbstractDocumentResource
     @POST
     @Consumes(MediaType.APPLICATION_XML)
     @Produces(MediaType.APPLICATION_ATOM_XML_ENTRY)
-    public Entry saveXmlDocument(@HeaderParam("Slug") String fileName, String body) {
-    	return super.saveArtifact(fileName, body, ArtifactType.XmlDocument);
+    public Entry saveXmlDocument(@HeaderParam("Slug") String fileName, String body) throws SrampAtomException {
+		return super.saveArtifact(fileName, body, ArtifactType.XmlDocument);
     }
   
 }

--- a/s-ramp-atom/src/main/java/org/overlord/sramp/atom/services/XsdDocumentResource.java
+++ b/s-ramp-atom/src/main/java/org/overlord/sramp/atom/services/XsdDocumentResource.java
@@ -29,7 +29,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MultivaluedMap;
-import javax.xml.bind.JAXBException;
 
 import org.jboss.resteasy.plugins.providers.atom.Entry;
 import org.jboss.resteasy.plugins.providers.atom.Feed;
@@ -39,6 +38,7 @@ import org.jboss.resteasy.plugins.providers.multipart.MultipartRelatedInput;
 import org.jboss.resteasy.util.GenericType;
 import org.overlord.sramp.ArtifactType;
 import org.overlord.sramp.atom.MediaType;
+import org.overlord.sramp.atom.err.SrampAtomException;
 import org.s_ramp.xmlns._2010.s_ramp.Artifact;
 import org.s_ramp.xmlns._2010.s_ramp.XsdDocument;
 
@@ -51,21 +51,34 @@ public class XsdDocumentResource extends AbstractDocumentResource
 	public XsdDocumentResource() {
 	}
 
+    /**
+     * S-RAMP atom POST to upload an XsdDocument to the repository.  This method handle a simple
+     * XML style POST.
+     * @param fileName
+     * @param body
+     * @throws SrampAtomException
+     */
     @POST
     @Consumes(MediaType.APPLICATION_XML)
     @Produces(MediaType.APPLICATION_ATOM_XML_ENTRY)
-    public Entry saveXsdDocument(@HeaderParam("Slug") String fileName, String body) {
+    public Entry saveXsdDocument(@HeaderParam("Slug") String fileName, String body) throws SrampAtomException {
     	return super.saveArtifact(fileName, body, ArtifactType.XsdDocument);
     }
 
+    /**
+     * S-RAMP atom POST to upload an XsdDocument to the repository.  This method handles the
+     * multipart/related style POST.
+     * @param input
+     * @throws SrampAtomException
+     */
     @POST
     @Consumes(MultipartConstants.MULTIPART_RELATED)
     @Produces(MediaType.APPLICATION_ATOM_XML_ENTRY)
-    public Entry saveXsdDocument(MultipartRelatedInput input) {
+    public Entry saveXsdDocument(MultipartRelatedInput input) throws SrampAtomException {
         try {
             List<InputPart> list = input.getParts();
             // Expecting 1 part. 
-            if (list.size()!=1) ; //throw error
+            if (list.size()!=1) ; //TODO throw error
             InputPart firstPart = list.get(0);
 
             // First part being the artifact
@@ -74,9 +87,10 @@ public class XsdDocumentResource extends AbstractDocumentResource
             InputStream is = firstPart.getBody(new GenericType<InputStream>() { });
             
             return super.saveArtifact(fileName, is, ArtifactType.XsdDocument);
-        } catch (Exception e) {
-        	// TODO need better error handling here
-        	throw new RuntimeException(e);
+        } catch (SrampAtomException e) {
+        	throw e;
+        } catch (Throwable e) {
+        	throw new SrampAtomException(e);
         }
     }
 
@@ -89,14 +103,15 @@ public class XsdDocumentResource extends AbstractDocumentResource
     @PUT
     @Path("{uuid}")
     @Consumes(MediaType.APPLICATION_ATOM_XML_ENTRY)
-    public void updateXsdDocument(@PathParam("uuid") String uuid, Entry atomEntry) {
+    public void updateXsdDocument(@PathParam("uuid") String uuid, Entry atomEntry) throws SrampAtomException {
     	try {
 			Artifact srampArtifactWrapper = atomEntry.getAnyOtherJAXBObject(Artifact.class);
 			XsdDocument xsdDocument = srampArtifactWrapper.getXsdDocument();
 			super.updateArtifact(xsdDocument, ArtifactType.XsdDocument);
-		} catch (JAXBException e) {
-        	// TODO need better error handling here
-        	throw new RuntimeException(e);
+    	} catch (SrampAtomException e) {
+    		throw e;
+		} catch (Throwable e) {
+        	throw new SrampAtomException(e);
 		}
     }
 
@@ -104,22 +119,24 @@ public class XsdDocumentResource extends AbstractDocumentResource
      * Called to get the {@link XsdDocument} with the supplied uuid.
      * @param uuid the UUID of the s-ramp artifact
      * @return an s-ramp extended Atom entry
+     * @throws SrampAtomException
      */
     @GET
     @Path("{uuid}")
     @Produces(MediaType.APPLICATION_ATOM_XML_ENTRY)
-    public Entry getXsdDocument(@PathParam("uuid") String uuid) {
+    public Entry getXsdDocument(@PathParam("uuid") String uuid) throws SrampAtomException {
     	return super.getArtifact(uuid, ArtifactType.XsdDocument);
     }
 
     /**
      * Returns a feed of summary documents for all XsdDocument artifacts.
      * @return artifact content stream
+     * @throws SrampAtomException
      */
     @GET
     @Path("{uuid}/media")
     @Produces(MediaType.TEXT_XML)
-    public InputStream getContent(@PathParam("uuid") String uuid) {
+    public InputStream getContent(@PathParam("uuid") String uuid) throws SrampAtomException {
     	return super.getArtifactContent(uuid, ArtifactType.XsdDocument);
     }
     
@@ -136,10 +153,11 @@ public class XsdDocumentResource extends AbstractDocumentResource
     /**
      * Returns a feed of summary documents for all XsdDocument artifacts.
      * @return an Atom {@link Feed}
+     * @throws SrampAtomException
      */
     @GET
     @Produces(MediaType.APPLICATION_ATOM_XML_FEED)
-    public Feed getFeed() {
+    public Feed getFeed() throws SrampAtomException {
     	return super.getFeed(ArtifactType.XsdDocument);
     }
 

--- a/s-ramp-atom/src/main/webapp/META-INF/MANIFEST.MF
+++ b/s-ramp-atom/src/main/webapp/META-INF/MANIFEST.MF
@@ -1,3 +1,0 @@
-Manifest-Version: 1.0
-Class-Path: 
-

--- a/s-ramp-atom/src/test/java/org/overlord/sramp/atom/services/XsdDocumentResourceTest.java
+++ b/s-ramp-atom/src/test/java/org/overlord/sramp/atom/services/XsdDocumentResourceTest.java
@@ -186,10 +186,12 @@ public class XsdDocumentResourceTest extends BaseResourceTest {
 		
 		String artifactFileName = "PO.xsd";
 		InputStream POXsd = this.getClass().getResourceAsStream("/sample-files/xsd/" + artifactFileName);
-		String expectedContent = TestUtils.convertStreamToString(POXsd);
-		POXsd.close();
-		
-		Assert.assertEquals(expectedContent, content);
+		try {
+			String expectedContent = TestUtils.convertStreamToString(POXsd);
+			Assert.assertEquals(expectedContent, content);
+		} finally {
+			POXsd.close();
+		}
 	}
 	
 	/**

--- a/s-ramp-client/pom.xml
+++ b/s-ramp-client/pom.xml
@@ -7,11 +7,11 @@
 		<version>0.0.1-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
-	
+
 	<artifactId>s-ramp-client</artifactId>
 	<name>S-RAMP Client</name>
 	<description>A general purpose client to communicate with any S-RAMP spec-compliant repository.</description>
-	
+
 	<dependencies>
 		<!-- S-RAMP project dependencies -->
 		<dependency>
@@ -24,7 +24,7 @@
 			<artifactId>s-ramp-core</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-		
+
 		<!-- Third party libraries -->
 		<dependency>
 			<groupId>com.sun.xml.bind</groupId>
@@ -62,13 +62,35 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+		</dependency>
 
 		<!-- Test dependencies -->
+		<dependency>
+			<groupId>org.overlord.sramp</groupId>
+			<artifactId>s-ramp-atom</artifactId>
+			<version>${project.version}</version>
+			<classifier>classes</classifier>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.jboss.resteasy</groupId>
+			<artifactId>tjws</artifactId>
+			<version>${org.jboss.resteasy.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>javax.servlet</groupId>
+			<artifactId>servlet-api</artifactId>
+			<scope>test</scope>
+		</dependency>
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
-	
+
 </project>

--- a/s-ramp-client/src/main/java/org/overlord/sramp/client/ClientRequest.java
+++ b/s-ramp-client/src/main/java/org/overlord/sramp/client/ClientRequest.java
@@ -18,13 +18,22 @@ package org.overlord.sramp.client;
 import javax.ws.rs.core.UriBuilder;
 
 import org.jboss.resteasy.client.ClientExecutor;
+import org.jboss.resteasy.client.ClientResponse;
 import org.jboss.resteasy.plugins.providers.RegisterBuiltin;
 import org.jboss.resteasy.specimpl.UriBuilderImpl;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
+import org.jboss.resteasy.util.HttpHeaderNames;
 
 /**
  * Extends the RESTEasy {@link org.jboss.resteasy.client.ClientRequest} class in order to provide a
  * {@link ClientExecutor} and {@link ResteasyProviderFactory} without requiring clients to pass them in.
+ * 
+ * Additionally, this class overrides the various http methods (post, get, put) in order to implement
+ * some error handling.  These methods will throw an appropriate exception now (when possible), rather 
+ * than a less meaningful RESTEasy generic exception.  When communicating with the JBoss s-ramp
+ * implementation, this error handling should work well (it should throw an exception that also includes
+ * the server-side root-cause stack trace).  When connecting to some other s-ramp implementation, your
+ * mileage may vary.
  * 
  * @author eric.wittmann@redhat.com
  */
@@ -33,14 +42,7 @@ public class ClientRequest extends org.jboss.resteasy.client.ClientRequest {
 	private static final ResteasyProviderFactory providerFactory = new ResteasyProviderFactory();
 	static {
 		RegisterBuiltin.register(providerFactory);
-	}
-
-	/**
-	 * Constructor.
-	 * @param uriTemplate
-	 */
-	public ClientRequest(String uriTemplate) {
-		super(getBuilder(uriTemplate), getDefaultExecutor(), providerFactory);
+		providerFactory.registerProvider(SrampClientExceptionReader.class);
 	}
 
 	/**
@@ -49,6 +51,78 @@ public class ClientRequest extends org.jboss.resteasy.client.ClientRequest {
 	 */
 	private static UriBuilder getBuilder(String uriTemplate) {
 		return new UriBuilderImpl().uriTemplate(uriTemplate);
+	}
+
+	
+	/**
+	 * Constructor.
+	 * @param uriTemplate
+	 */
+	public ClientRequest(String uriTemplate) {
+		super(getBuilder(uriTemplate), getDefaultExecutor(), providerFactory);
+	}
+	
+	/**
+	 * @see org.jboss.resteasy.client.ClientRequest#post(java.lang.Class)
+	 */
+	@Override
+	public <T> ClientResponse<T> post(Class<T> returnType) throws Exception {
+		ClientResponse<T> response = super.post(returnType);
+		handlePotentialServerError(response);
+		return response;
+	}
+	
+	/**
+	 * @see org.jboss.resteasy.client.ClientRequest#get(java.lang.Class)
+	 */
+	@Override
+	public <T> ClientResponse<T> get(Class<T> returnType) throws Exception {
+		ClientResponse<T> response = super.get(returnType);
+		handlePotentialServerError(response);
+		return response;
+	}
+	
+	/**
+	 * @see org.jboss.resteasy.client.ClientRequest#put(java.lang.Class)
+	 */
+	@Override
+	public <T> ClientResponse<T> put(Class<T> returnType) throws Exception {
+		ClientResponse<T> response = super.put(returnType);
+		handlePotentialServerError(response);
+		return response;
+	}
+	
+	/**
+	 * @see org.jboss.resteasy.client.ClientRequest#delete(java.lang.Class)
+	 */
+	@Override
+	public <T> ClientResponse<T> delete(Class<T> returnType) throws Exception {
+		ClientResponse<T> response = super.delete(returnType);
+		handlePotentialServerError(response);
+		return response;
+	}
+
+	/**
+	 * Handles the possibility of an error found in the response.
+	 * @param response
+	 */
+	private <T> void handlePotentialServerError(ClientResponse<T> response) {
+		String contentType = String.valueOf(response.getMetadata().getFirst(HttpHeaderNames.CONTENT_TYPE));
+		if (response.getStatus() == 500) {
+			SrampServerException error = new SrampServerException("An unexpected (and unknown) error was sent by the S-RAMP repository.");
+			if ("application/stacktrace".equals(contentType)) {
+				try {
+					SrampServerException entity = response.getEntity(SrampServerException.class);
+					if (entity != null)
+						error = entity;
+				} catch (Throwable t) {}
+			}
+			throw error;
+		}
+		if (response.getStatus() == 404) {
+			SrampServerException error = new SrampServerException("The S-RAMP endpoint and/or method could not be found.");
+			throw error;
+		}
 	}
 
 }

--- a/s-ramp-client/src/main/java/org/overlord/sramp/client/SrampClientException.java
+++ b/s-ramp-client/src/main/java/org/overlord/sramp/client/SrampClientException.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2012 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.overlord.sramp.client;
+
+/**
+ * Exception thrown by the S-RAMP client when an error of some kind is encountered.
+ *
+ * @author eric.wittmann@redhat.com
+ */
+public class SrampClientException extends Exception {
+
+	private static final long serialVersionUID = -5164848692868850533L;
+
+	/**
+	 * Constructor.
+	 */
+	public SrampClientException() {
+	}
+
+	/**
+	 * Constructor.
+	 * @param message
+	 */
+	public SrampClientException(String message) {
+		super(message);
+	}
+
+	/**
+	 * Constructor.
+	 * @param message
+	 * @param cause
+	 */
+	public SrampClientException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	/**
+	 * Constructor.
+	 * @param cause
+	 */
+	public SrampClientException(Throwable cause) {
+		super(cause);
+	}
+
+}

--- a/s-ramp-client/src/main/java/org/overlord/sramp/client/SrampClientExceptionReader.java
+++ b/s-ramp-client/src/main/java/org/overlord/sramp/client/SrampClientExceptionReader.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2012 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.overlord.sramp.client;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.List;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.MessageBodyReader;
+import javax.ws.rs.ext.Provider;
+
+import org.apache.commons.io.IOUtils;
+
+/**
+ * A RESTEasy message body reader that is capable of reading an exception from the 
+ * response body.
+ *
+ * @author eric.wittmann@redhat.com
+ */
+@Provider
+public class SrampClientExceptionReader implements MessageBodyReader<SrampServerException> {
+
+	/**
+	 * Constructor.
+	 */
+	public SrampClientExceptionReader() {
+	}
+
+	/**
+	 * @see javax.ws.rs.ext.MessageBodyReader#isReadable(java.lang.Class, java.lang.reflect.Type, java.lang.annotation.Annotation[], javax.ws.rs.core.MediaType)
+	 */
+	@Override
+	public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+		return "application/stacktrace".equals(mediaType.toString());
+	}
+
+	/**
+	 * @see javax.ws.rs.ext.MessageBodyReader#readFrom(java.lang.Class, java.lang.reflect.Type, java.lang.annotation.Annotation[], javax.ws.rs.core.MediaType, javax.ws.rs.core.MultivaluedMap, java.io.InputStream)
+	 */
+	@Override
+	public SrampServerException readFrom(Class<SrampServerException> type, Type genericType, Annotation[] annotations,
+			MediaType mediaType, MultivaluedMap<String, String> httpHeaders, InputStream entityStream)
+			throws IOException, WebApplicationException {
+		List<String> lines = (List<String>) IOUtils.readLines(entityStream);
+		StringBuilder buffer = new StringBuilder();
+		for (String line : lines) {
+			buffer.append(line).append("\n");
+		}
+		String remoteStackTrace = buffer.toString();
+		SrampServerException error = new SrampServerException("An unexpected error was thrown by the S-RAMP repository.");
+		error.setRemoteStackTrace(remoteStackTrace);
+		return error;
+	}
+
+}

--- a/s-ramp-client/src/main/java/org/overlord/sramp/client/SrampServerException.java
+++ b/s-ramp-client/src/main/java/org/overlord/sramp/client/SrampServerException.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2012 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.overlord.sramp.client;
+
+/**
+ * Exception thrown by the S-RAMP client when an error is received from the 
+ * s-ramp server (repository).
+ *
+ * @author eric.wittmann@redhat.com
+ */
+public class SrampServerException extends RuntimeException {
+
+	private static final long serialVersionUID = -40629222359166674L;
+	
+	private String remoteStackTrace;
+
+	/**
+	 * Constructor.
+	 */
+	public SrampServerException() {
+	}
+
+	/**
+	 * Constructor.
+	 * @param message
+	 */
+	public SrampServerException(String message) {
+		super(message);
+	}
+
+	/**
+	 * Constructor.
+	 * @param message
+	 * @param cause
+	 */
+	public SrampServerException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	/**
+	 * Constructor.
+	 * @param cause
+	 */
+	public SrampServerException(Throwable cause) {
+		super(cause);
+	}
+
+	/**
+	 * @return the remoteStackTrace
+	 */
+	public String getRemoteStackTrace() {
+		return remoteStackTrace;
+	}
+
+	/**
+	 * @param remoteStackTrace the remoteStackTrace to set
+	 */
+	public void setRemoteStackTrace(String remoteStackTrace) {
+		this.remoteStackTrace = remoteStackTrace;
+	}
+
+}

--- a/s-ramp-client/src/test/java/org/overlord/sramp/client/SrampAtomApiClientTest.java
+++ b/s-ramp-client/src/test/java/org/overlord/sramp/client/SrampAtomApiClientTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2012 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.overlord.sramp.client;
+
+import static org.jboss.resteasy.test.TestPortProvider.generateURL;
+import static org.junit.Assert.fail;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.util.List;
+
+import junit.framework.Assert;
+
+import org.jboss.resteasy.plugins.providers.atom.Entry;
+import org.jboss.resteasy.plugins.providers.atom.Feed;
+import org.jboss.resteasy.test.BaseResourceTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.overlord.sramp.atom.err.SrampAtomExceptionMapper;
+import org.overlord.sramp.atom.services.AdHocQueryResource;
+import org.overlord.sramp.atom.services.XsdDocumentResource;
+
+/**
+ * Unit test for the 
+ *
+ * @author eric.wittmann@redhat.com
+ */
+public class SrampAtomApiClientTest extends BaseResourceTest {
+
+	@Before
+	public void setUp() throws Exception {
+		getProviderFactory().registerProvider(SrampAtomExceptionMapper.class);
+		dispatcher.getRegistry().addPerRequestResource(XsdDocumentResource.class);
+		dispatcher.getRegistry().addPerRequestResource(AdHocQueryResource.class);
+	}
+
+	/**
+	 * Test method for {@link org.overlord.sramp.client.SrampAtomApiClient#uploadArtifact(java.lang.String, java.lang.String, java.io.InputStream, java.lang.String)}.
+	 */
+	@Test
+	public void testUploadArtifact() throws Exception {
+		String artifactFileName = "PO.xsd";
+		InputStream is = this.getClass().getResourceAsStream("/sample-files/xsd/" + artifactFileName);
+		try {
+			SrampAtomApiClient client = new SrampAtomApiClient(generateURL("/s-ramp"));
+			Entry entry = client.uploadArtifact("xsd", "XsdDocument", is, artifactFileName);
+			Assert.assertNotNull(entry);
+			Assert.assertEquals(artifactFileName, entry.getTitle());
+		} finally {
+			is.close();
+		}
+	}
+
+	/**
+	 * Test method for {@link org.overlord.sramp.client.SrampAtomApiClient#getArtifactContent(java.lang.String, java.lang.String, java.lang.String)}.
+	 */
+	@Test
+	public void testGetArtifactContent() throws Exception {
+		SrampAtomApiClient client = new SrampAtomApiClient(generateURL("/s-ramp"));
+		URI uuid = null;
+		
+		// First, upload an artifact so we have some content to get
+		String artifactFileName = "PO.xsd";
+		InputStream is = this.getClass().getResourceAsStream("/sample-files/xsd/" + artifactFileName);
+		try {
+			Entry entry = client.uploadArtifact("xsd", "XsdDocument", is, artifactFileName);
+			Assert.assertNotNull(entry);
+			Assert.assertEquals(artifactFileName, entry.getTitle());
+			uuid = entry.getId();
+		} finally {
+			is.close();
+		}
+		
+		// Now get the content.
+		InputStream content = client.getArtifactContent("xsd", "XsdDocument", uuid.toString());
+		try {
+			Assert.assertNotNull(content);
+			BufferedReader reader = new BufferedReader(new InputStreamReader(content));
+			String line1 = reader.readLine();
+			String line2 = reader.readLine();
+			Assert.assertTrue("Unexpected content found.", line1.startsWith("<?xml version=\"1.0\""));
+			Assert.assertTrue("Unexpected content found.", line2.startsWith("<xsd:schema"));
+		} finally {
+			content.close();
+		}
+	}
+
+	/**
+	 * Test method for {@link org.overlord.sramp.client.SrampAtomApiClient#query(java.lang.String, int, int, java.lang.String, boolean)}.
+	 */
+	@Test
+	public void testQuery() throws Exception {
+		SrampAtomApiClient client = new SrampAtomApiClient(generateURL("/s-ramp"));
+		URI uuid = null;
+
+		// First add an artifact so we have something to search for
+		String artifactFileName = "PO.xsd";
+		InputStream is = this.getClass().getResourceAsStream("/sample-files/xsd/" + artifactFileName);
+		try {
+			Entry entry = client.uploadArtifact("xsd", "XsdDocument", is, artifactFileName);
+			Assert.assertNotNull(entry);
+			Assert.assertEquals(artifactFileName, entry.getTitle());
+			uuid = entry.getId();
+		} finally {
+			is.close();
+		}
+		
+		// Now search for all XSDs
+		Feed feed = client.query("/s-ramp/xsd/XsdDocument", 0, 50, "name", false);
+		List<Entry> entries = feed.getEntries();
+		boolean uuidFound = false;
+		for (Entry entry : entries) {
+			if (entry.getId().equals(uuid))
+				uuidFound = true;
+		}
+		Assert.assertTrue("Failed to find the artifact we just added!", uuidFound);
+	}
+
+	/**
+	 * Test method for {@link org.overlord.sramp.client.SrampAtomApiClient#uploadArtifact(java.lang.String, java.lang.String, java.io.InputStream, java.lang.String)}.
+	 */
+	@Test
+	public void testQueryError() throws Exception {
+		SrampAtomApiClient client = new SrampAtomApiClient(generateURL("/s-ramp"));
+		try {
+			Feed feed = client.query("12345", 0, 20, "name", false);
+			fail("Expected a remote exception from the s-ramp server, but got: " + feed);
+		} catch (SrampServerException e) {
+			String remoteTrace = e.getRemoteStackTrace();
+			Assert.assertNotNull(remoteTrace);
+			Assert.assertTrue(remoteTrace.startsWith("org.overlord.sramp.query.xpath.XPathParserException: Invalid artifact set (step 2)."));
+		}
+	}
+
+}

--- a/s-ramp-client/src/test/resources/log4j.properties
+++ b/s-ramp-client/src/test/resources/log4j.properties
@@ -1,0 +1,11 @@
+# Direct log messages to stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{ABSOLUTE} %5p %m%n
+
+# Root logger option
+log4j.rootLogger=INFO, stdout
+
+# Set up the default logging to be INFO level, then override specific units
+log4j.logger.org.modeshape=INFO

--- a/s-ramp-client/src/test/resources/sample-files/xml/PO.xml
+++ b/s-ramp-client/src/test/resources/sample-files/xml/PO.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<purchaseOrder orderDate="1999-10-20">
+	<shipTo country="US">
+		<name>Alice Smith</name>
+		<street>123 Maple Street</street>
+		<city>Mill Valley</city>
+		<state>CA</state>
+		<zip>90952</zip>
+	</shipTo>
+	<billTo country="US">
+		<name>Robert Smith</name>
+		<street>8 Oak Avenue</street>
+		<city>Old Town</city>
+		<state>PA</state>
+		<zip>95819</zip>
+	</billTo>
+	<comment>Hurry, my lawn is going wild</comment>
+		<items>
+			<item partNum="872-AA">
+				<productName>Lawnmower</productName>
+				<quantity>1</quantity>
+				<USPrice>148.95</USPrice>
+				<comment>Confirm this is electric</comment>
+			</item>
+			<item partNum="926-AA">
+				<productName>Baby Monitor</productName>
+				<quantity>1</quantity>
+				<USPrice>39.98</USPrice>
+				<shipDate>1999-05-21</shipDate>
+			</item>
+		</items>
+</purchaseOrder>

--- a/s-ramp-client/src/test/resources/sample-files/xsd/PO.xsd
+++ b/s-ramp-client/src/test/resources/sample-files/xsd/PO.xsd
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" version="1.0">
+ 
+  <xsd:annotation>
+    <xsd:documentation xml:lang="en">
+     Purchase order schema for Example.com.
+     Copyright 2000 Example.com. All rights reserved.
+    </xsd:documentation>
+  </xsd:annotation>
+ 
+  <xsd:element name="purchaseOrder" type="PurchaseOrderType" />
+ 
+  <xsd:element name="comment" type="xsd:string"/>
+ 
+  <xsd:complexType name="PurchaseOrderType">
+    <xsd:sequence>
+      <xsd:element name="shipTo" type="USAddress"/>
+      <xsd:element name="billTo" type="USAddress"/>
+      <xsd:element ref="comment" minOccurs="0"/>
+      <xsd:element name="items"  type="Items"/>
+    </xsd:sequence>
+    <xsd:attribute name="orderDate" type="xsd:date"/>
+  </xsd:complexType>
+ 
+  <xsd:complexType name="USAddress">
+    <xsd:sequence>
+      <xsd:element name="name"   type="xsd:string"/>
+      <xsd:element name="street" type="xsd:string"/>
+      <xsd:element name="city"   type="xsd:string"/>
+      <xsd:element name="state"  type="xsd:string"/>
+      <xsd:element name="zip"    type="xsd:decimal"/>
+    </xsd:sequence>
+    <xsd:attribute name="country" type="xsd:NMTOKEN"
+                   fixed="US"/>
+  </xsd:complexType>
+ 
+  <xsd:complexType name="Items">
+    <xsd:sequence>
+      <xsd:element name="item" minOccurs="0" maxOccurs="unbounded">
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:element name="productName" type="xsd:string"/>
+            <xsd:element name="quantity">
+              <xsd:simpleType>
+                <xsd:restriction base="xsd:positiveInteger">
+                  <xsd:maxExclusive value="100"/>
+                </xsd:restriction>
+              </xsd:simpleType>
+            </xsd:element>
+            <xsd:element name="USPrice"  type="xsd:decimal"/>
+            <xsd:element ref="comment"   minOccurs="0"/>
+            <xsd:element name="shipDate" type="xsd:date" minOccurs="0"/>
+          </xsd:sequence>
+          <xsd:attribute name="partNum" type="SKU" use="required"/>
+        </xsd:complexType>
+      </xsd:element>
+    </xsd:sequence>
+  </xsd:complexType>
+ 
+  <!-- Stock Keeping Unit, a code for identifying products -->
+  <xsd:simpleType name="SKU">
+    <xsd:restriction base="xsd:string">
+      <xsd:pattern value="\d{3}-[A-Z]{2}"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+ 
+</xsd:schema>

--- a/s-ramp-core/pom.xml
+++ b/s-ramp-core/pom.xml
@@ -38,7 +38,7 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.commons</groupId>
+			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
 			<scope>test</scope>
 		</dependency>

--- a/s-ramp-core/src/test/java/org/overlord/sramp/query/xpath/XPathParserTest.java
+++ b/s-ramp-core/src/test/java/org/overlord/sramp/query/xpath/XPathParserTest.java
@@ -86,7 +86,6 @@ public class XPathParserTest {
 		if (!testCaseDir.isDirectory())
 			throw new Exception("Failed to find test case directory: " + testCaseDirUrl);
 		
-		@SuppressWarnings("unchecked")
 		Collection<File> testCaseFiles = (Collection<File>) FileUtils.listFiles(testCaseDir, new String[] { "properties" }, true);
 		testCaseFiles = new TreeSet<File>(testCaseFiles);
 		Collection<Properties> testCases = new ArrayList<Properties>(testCaseFiles.size());

--- a/s-ramp-parent/pom.xml
+++ b/s-ramp-parent/pom.xml
@@ -70,12 +70,8 @@
 	<properties>
 		<!-- Instruct the build to use only UTF-8 encoding for source code -->
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<junit.version>4.8.2</junit.version>
-		<log4j.version>1.2.16</log4j.version>
-		<slf4j.api.version>1.5.11</slf4j.api.version>
-		<slf4j.log4j.version>1.5.11</slf4j.log4j.version>
-		<xmlunit.version>1.3</xmlunit.version>
-		
+		<maven.build.timestamp.format>yyyy-MM-dd HH:mm:ss</maven.build.timestamp.format>
+
 		<!-- Distribution URLs -->
 		<jboss.releases.repo.url>https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/</jboss.releases.repo.url>
 		<jboss.snapshots.repo.url>https://repository.jboss.org/nexus/content/repositories/snapshots/</jboss.snapshots.repo.url>
@@ -93,11 +89,17 @@
 		<maven.compiler.plugin.version>2.3.2</maven.compiler.plugin.version>
 		<maven.source.plugin.version>2.1.2</maven.source.plugin.version>
 		<maven.deploy.plugin.version>2.5</maven.deploy.plugin.version>
-		<!-- from other modules -->
+
+		<!-- Dependency versions -->
+		<junit.version>4.8.2</junit.version>
+		<log4j.version>1.2.16</log4j.version>
+		<slf4j.api.version>1.5.11</slf4j.api.version>
+		<slf4j.log4j.version>1.5.11</slf4j.log4j.version>
+		<xmlunit.version>1.3</xmlunit.version>
+		<servlet.api.version>2.5</servlet.api.version>
 		<org.jboss.resteasy.version>2.3.4.Final</org.jboss.resteasy.version>
 		<org.modeshape.version>3.0.0.Alpha6</org.modeshape.version>
-		<!-- Apache Commons -->
-		<commons.io.version>1.3.2</commons.io.version>
+		<commons.io.version>2.4</commons.io.version>
 		<commons.lang3.version>3.1</commons.lang3.version>
 		<commons.config.version>1.8</commons.config.version>
 	</properties>
@@ -113,6 +115,11 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-jar-plugin</artifactId>
 					<version>${maven.jar.plugin.version}</version>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-war-plugin</artifactId>
+					<version>${maven.war.plugin.version}</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
@@ -180,7 +187,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
-				<version>${maven.jar.plugin.version}</version><!--$NO-MVN-MAN-VER$-->
+				<version>${maven.jar.plugin.version}</version><!--$NO-MVN-MAN-VER$ -->
 				<executions>
 					<execution>
 						<id>test-jar</id>
@@ -213,7 +220,7 @@
 				<version>${commons.lang3.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>org.apache.commons</groupId>
+				<groupId>commons-io</groupId>
 				<artifactId>commons-io</artifactId>
 				<version>${commons.io.version}</version>
 			</dependency>
@@ -222,7 +229,13 @@
 				<artifactId>commons-configuration</artifactId>
 				<version>${commons.config.version}</version>
 			</dependency>
-			<!-- Logging (require SLF4J API for compiling, but use Log4J and its SLF4J binding for testing) -->
+			<dependency>
+				<groupId>javax.servlet</groupId>
+				<artifactId>servlet-api</artifactId>
+				<version>${servlet.api.version}</version>
+			</dependency>
+			<!-- Logging (require SLF4J API for compiling, but use Log4J and its SLF4J 
+				binding for testing) -->
 			<dependency>
 				<groupId>org.slf4j</groupId>
 				<artifactId>slf4j-api</artifactId>

--- a/s-ramp-repository-jcr/pom.xml
+++ b/s-ramp-repository-jcr/pom.xml
@@ -50,7 +50,7 @@
 		</dependency>
 		<!-- Common libraries -->
 		<dependency>
-			<groupId>org.apache.commons</groupId>
+			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
 		</dependency>
 		<!-- Testing (note the scope) -->

--- a/s-ramp-wagon/pom.xml
+++ b/s-ramp-wagon/pom.xml
@@ -11,7 +11,7 @@
 	<artifactId>s-ramp-wagon</artifactId>
 	<name>Maven S-RAMP Wagon Provider</name>
 	<description>Maven Wagon that gets and puts artifacts from and to remote server using the S-RAMP Atom API.</description>
-	
+
 	<properties>
 		<maven.version>3.0</maven.version>
 		<wagon.version>2.2</wagon.version>
@@ -34,7 +34,7 @@
 			<artifactId>wagon-provider-api</artifactId>
 			<version>${wagon.version}</version>
 		</dependency>
-		
+
 		<!-- S-RAMP project dependencies -->
 		<dependency>
 			<groupId>org.overlord.sramp</groupId>
@@ -51,7 +51,7 @@
 			<artifactId>s-ramp-client</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-		
+
 		<!-- Third party libraries -->
 
 		<!-- Common libraries -->
@@ -60,7 +60,7 @@
 			<artifactId>commons-lang3</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.commons</groupId>
+			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
 		</dependency>
 


### PR DESCRIPTION
Significant improvements to error handling in the Atom layer.  The Atom
layer now writes any exception it sees to the response.  The client can
then read the serialized exception from the response and propagate it
out to the original caller (the consumer of the s-ramp client).

Also added some basic unit tests for the s-ramp client.
