### PR TITLE
(sramp-39) Get s-ramp release build working

### DIFF
--- a/s-ramp-parent/pom.xml
+++ b/s-ramp-parent/pom.xml
@@ -27,8 +27,8 @@
 	</licenses>
 
 	<scm>
-		<connection>scm:git:git://github.com/Governance/s-ramp.git</connection>
-		<developerConnection>scm:git:git@github.com:Governance/s-ramp.git</developerConnection>
+        <connection>scm:git:git@github.com:Governance/${project.artifactId}.git</connection>
+        <developerConnection>scm:git:git@github.com:Governance/${project.artifactId}.git</developerConnection>
 		<url>http://github.com/Governance/s-ramp</url>
 	</scm>
 


### PR DESCRIPTION
Update to <scm> info to hopefully get a maven release build working in
jenkins.
