### PR TITLE
(sramp-52) Update meta-data in the persistence layer

### DIFF
--- a/s-ramp-repository-jcr/src/main/java/org/overlord/sramp/repository/jcr/JCRPersistence.java
+++ b/s-ramp-repository-jcr/src/main/java/org/overlord/sramp/repository/jcr/JCRPersistence.java
@@ -274,14 +274,10 @@ public class JCRPersistence implements PersistenceManager, DerivedArtifacts {
             Node sequencedNode = session.getNode(sequencedArtifactPath);
             UpdateJCRNodeFromArtifactVisitor visitor = new UpdateJCRNodeFromArtifactVisitor(sequencedNode);
             ArtifactVisitorHelper.visitArtifact(visitor, artifact);
+            if (visitor.hasError())
+            	throw visitor.getError();
             session.save();
-        } catch (LoginException e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
-        } catch (NoSuchWorkspaceException e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
-        } catch (RepositoryException e) {
+        } catch (Exception e) {
             // TODO Auto-generated catch block
             e.printStackTrace();
         } finally {

--- a/s-ramp-repository-jcr/src/main/java/org/overlord/sramp/repository/jcr/UpdateJCRNodeFromArtifactVisitor.java
+++ b/s-ramp-repository-jcr/src/main/java/org/overlord/sramp/repository/jcr/UpdateJCRNodeFromArtifactVisitor.java
@@ -30,8 +30,8 @@ import org.s_ramp.xmlns._2010.s_ramp.XsdDocument;
  */
 public class UpdateJCRNodeFromArtifactVisitor extends ArtifactVisitorAdapter {
 
-	@SuppressWarnings("unused")
 	private Node jcrNode;
+	private Exception error;
 	
 	/**
 	 * Constructor.
@@ -46,7 +46,30 @@ public class UpdateJCRNodeFromArtifactVisitor extends ArtifactVisitorAdapter {
 	 * @param artifact the artifact being visited
 	 */
 	protected void visitBaseArtifact(BaseArtifactType artifact) {
-		
+		try {
+			if (artifact.getName() != null)
+				this.jcrNode.setProperty("sramp:name", artifact.getName());
+			if (artifact.getDescription() != null)
+				this.jcrNode.setProperty("sramp:description", artifact.getDescription());
+			if (artifact.getVersion() != null)
+				this.jcrNode.setProperty("version", artifact.getVersion());
+		} catch (Exception e) {
+			error = e;
+		}
+	}
+	
+	/**
+	 * Returns true if this visitor encountered an error during visitation.
+	 */
+	public boolean hasError() {
+		return error != null;
+	}
+	
+	/**
+	 * Returns the error encountered during visitation.
+	 */
+	public Exception getError() {
+		return error;
 	}
 
 	/**

--- a/s-ramp-repository-jcr/src/test/java/org/overlord/sramp/repository/jcr/JCRPersistenceTest.java
+++ b/s-ramp-repository-jcr/src/test/java/org/overlord/sramp/repository/jcr/JCRPersistenceTest.java
@@ -142,4 +142,30 @@ public class JCRPersistenceTest {
 		Assert.assertTrue("Failed to find UUID2.", foundUuid2);
     }
 
+    @Test
+    public void testUpdateMetaData() throws Exception {
+    	// First, add an artifact to the repo
+        String artifactFileName = "PO.xsd";
+        InputStream POXsd = this.getClass().getResourceAsStream("/sample-files/xsd/" + artifactFileName);
+        BaseArtifactType artifact = persistenceManager.persistArtifact(artifactFileName, ArtifactType.XsdDocument, POXsd);
+        Assert.assertNotNull(artifact);
+        log.info("persisted PO.xsd to JCR, returned artifact uuid=" + artifact.getUuid());
+        Assert.assertEquals(XsdDocument.class, artifact.getClass());
+        Assert.assertEquals(new Long(2376l), ((XsdDocument) artifact).getContentSize());
+        Assert.assertEquals(artifactFileName, artifact.getName());
+        
+        // Now update the artifact
+        artifact = persistenceManager.getArtifact(artifact.getUuid(), ArtifactType.XsdDocument);
+        artifact.setName("My PO");
+        artifact.setDescription("A new description of the PO.xsd artifact.");
+        artifact.setVersion("2.0.13");
+        persistenceManager.updateArtifact(artifact, ArtifactType.XsdDocument);
+        
+        // Now verify the meta-data was updated
+        artifact = persistenceManager.getArtifact(artifact.getUuid(), ArtifactType.XsdDocument);
+        Assert.assertEquals("My PO", artifact.getName());
+        Assert.assertEquals("A new description of the PO.xsd artifact.", artifact.getDescription());
+        Assert.assertEquals("2.0.13", artifact.getVersion());
+    }
+
 }


### PR DESCRIPTION
S-ramp standard meta-data properties are now being updated in the
persistence layer.
