### PR TITLE
(sramp-43) Add 'update meta data' to the s-ramp client

### DIFF
--- a/s-ramp-atom/src/test/java/org/overlord/sramp/atom/services/XsdDocumentResourceTest.java
+++ b/s-ramp-atom/src/test/java/org/overlord/sramp/atom/services/XsdDocumentResourceTest.java
@@ -40,7 +40,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.overlord.sramp.atom.MediaType;
 import org.s_ramp.xmlns._2010.s_ramp.Artifact;
-import org.s_ramp.xmlns._2010.s_ramp.Property;
 import org.s_ramp.xmlns._2010.s_ramp.XsdDocument;
 
 import test.org.overlord.sramp.atom.TestUtils;
@@ -100,9 +99,7 @@ public class XsdDocumentResourceTest extends BaseResourceTest {
 		// Update
 		doUpdateXsdEntry(entry);
 		entry = doGetXsdEntry(entryId);
-		// TODO re-enable once update is fully implemented (see UpdateJCRNodeFromArtifactVisitor)
-//		verifyEntryUpdated(entry);
-		
+		verifyEntryUpdated(entry);
 		
 		// TODO implement delete functionality
 //		deleteXsdEntry(entryId);
@@ -225,17 +222,11 @@ public class XsdDocumentResourceTest extends BaseResourceTest {
 	 * @throws Exception 
 	 */
 	private void doUpdateXsdEntry(Entry entry) throws Exception {
-		// TODO I think the entryId should be of the format urn:{uuid} and we'll need to parse it - this isn't happening right now though
-		String uuid = entry.getId().toString();
-
 		// First, make a change to the entry.
 		Artifact srampArtifactWrapper = entry.getAnyOtherJAXBObject(Artifact.class);
 		XsdDocument xsdDocument = srampArtifactWrapper.getXsdDocument();
-		xsdDocument.getClassifiedBy().add("http://example.org/ontologies/account.owl/accounts");
-		Property newProperty = new Property();
-		newProperty.setPropertyName("accountingCalendar");
-		newProperty.setPropertyValue("2009");
-		xsdDocument.getProperty().add(newProperty);
+		String uuid = xsdDocument.getUuid();
+		xsdDocument.setDescription("** Updated description! **");
 		
 		entry.setAnyOtherJAXBObject(srampArtifactWrapper);
 		
@@ -252,15 +243,10 @@ public class XsdDocumentResourceTest extends BaseResourceTest {
 	 * the update phase of the test.
 	 * @param entry
 	 */
-	@SuppressWarnings("unused")
 	private void verifyEntryUpdated(Entry entry) throws Exception {
 		Artifact srampArtifactWrapper = entry.getAnyOtherJAXBObject(Artifact.class);
 		XsdDocument xsdDocument = srampArtifactWrapper.getXsdDocument();
-		Assert.assertFalse(xsdDocument.getClassifiedBy().isEmpty());
-		Assert.assertEquals("http://example.org/ontologies/account.owl/accounts", xsdDocument.getClassifiedBy().get(0));
-		Assert.assertFalse(xsdDocument.getProperty().isEmpty());
-		Assert.assertEquals("accountingCalendar", xsdDocument.getProperty().get(0).getPropertyName());
-		Assert.assertEquals("2009", xsdDocument.getProperty().get(0).getPropertyValue());
+		Assert.assertEquals("** Updated description! **", xsdDocument.getDescription());
 	}
 
 }

--- a/s-ramp-client/src/main/java/org/overlord/sramp/client/SrampAtomApiClient.java
+++ b/s-ramp-client/src/main/java/org/overlord/sramp/client/SrampAtomApiClient.java
@@ -25,6 +25,7 @@ import org.jboss.resteasy.plugins.providers.atom.Entry;
 import org.jboss.resteasy.plugins.providers.atom.Feed;
 import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataOutput;
 import org.overlord.sramp.ArtifactType;
+import org.s_ramp.xmlns._2010.s_ramp.BaseArtifactType;
 
 /**
  * Class used to communicate with the S-RAMP server.
@@ -153,6 +154,33 @@ public class SrampAtomApiClient {
 	public Entry uploadArtifact(ArtifactType artifactType, InputStream content, String artifactFileName)
 			throws SrampClientException, SrampServerException {
 		return uploadArtifact(artifactType.getModel(), artifactType.name(), content, artifactFileName);
+	}
+	
+	/**
+	 * Called to update the meta-data stored in the s-ramp repository for the given s-ramp
+	 * artifact.
+	 * @param artifact
+	 * @throws SrampClientException
+	 */
+	public void updateArtifactMetaData(BaseArtifactType artifact) throws SrampClientException {
+		try {
+			ArtifactType type = ArtifactType.valueOf(artifact);
+			String artifactModel = type.getModel();
+			String artifactType = type.name();
+			String artifactUuid = artifact.getUuid();
+			String atomUrl = String.format("%1$s/%2$s/%3$s/%4$s", this.endpoint, artifactModel, artifactType, artifactUuid);
+			ClientRequest request = new ClientRequest(atomUrl);
+
+			Entry entry = SrampClientUtils.wrapSrampArtifact(artifact);
+			
+			request.body(MediaType.APPLICATION_ATOM_XML, entry);
+			request.put();
+		} catch (SrampServerException e) {
+			throw e;
+		} catch (Throwable e) {
+			throw new SrampClientException(e);
+		}
+
 	}
 
 	/**

--- a/s-ramp-client/src/main/java/org/overlord/sramp/client/SrampClientUtils.java
+++ b/s-ramp-client/src/main/java/org/overlord/sramp/client/SrampClientUtils.java
@@ -15,12 +15,16 @@
  */
 package org.overlord.sramp.client;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.net.URI;
+import java.net.URISyntaxException;
 
 import javax.xml.bind.JAXBException;
 
 import org.jboss.resteasy.plugins.providers.atom.Entry;
 import org.jboss.resteasy.plugins.providers.atom.Link;
+import org.jboss.resteasy.plugins.providers.atom.Person;
 import org.overlord.sramp.ArtifactType;
 import org.s_ramp.xmlns._2010.s_ramp.Artifact;
 import org.s_ramp.xmlns._2010.s_ramp.BaseArtifactType;
@@ -85,6 +89,33 @@ public final class SrampClientUtils {
 	public static BaseArtifactType unwrapSrampArtifact(ArtifactType artifactType, Entry entry) throws JAXBException {
 		Artifact artifact = entry.getAnyOtherJAXBObject(Artifact.class);
 		return unwrapSrampArtifact(artifactType, artifact);
+	}
+	
+	/**
+	 * Wraps the given s-ramp artifact in an Atom {@link Entry}.
+	 * @param artifact
+	 * @throws URISyntaxException 
+	 * @throws InvocationTargetException 
+	 * @throws IllegalAccessException 
+	 * @throws IllegalArgumentException 
+	 * @throws NoSuchMethodException 
+	 * @throws SecurityException 
+	 */
+	public static Entry wrapSrampArtifact(BaseArtifactType artifact) throws URISyntaxException, IllegalArgumentException, IllegalAccessException, InvocationTargetException, SecurityException, NoSuchMethodException {
+		Entry entry = new Entry();
+		entry.setId(new URI(artifact.getUuid()));
+		entry.setUpdated(artifact.getLastModifiedTimestamp().toGregorianCalendar().getTime());
+		entry.setTitle(artifact.getName());
+		entry.setPublished(artifact.getCreatedTimestamp().toGregorianCalendar().getTime());
+		entry.getAuthors().add(new Person(artifact.getCreatedBy()));
+		entry.setSummary(artifact.getDescription());
+
+        Artifact srampArty = new Artifact();
+        Method method = Artifact.class.getMethod("set" + artifact.getClass().getSimpleName(), artifact.getClass());
+        method.invoke(srampArty, artifact);
+        entry.setAnyOtherJAXBObject(srampArty);
+		
+		return entry;
 	}
 
 	/**

--- a/s-ramp-client/src/test/java/org/overlord/sramp/client/SrampAtomApiClientTest.java
+++ b/s-ramp-client/src/test/java/org/overlord/sramp/client/SrampAtomApiClientTest.java
@@ -31,9 +31,11 @@ import org.jboss.resteasy.plugins.providers.atom.Feed;
 import org.jboss.resteasy.test.BaseResourceTest;
 import org.junit.Before;
 import org.junit.Test;
+import org.overlord.sramp.ArtifactType;
 import org.overlord.sramp.atom.err.SrampAtomExceptionMapper;
 import org.overlord.sramp.atom.services.AdHocQueryResource;
 import org.overlord.sramp.atom.services.XsdDocumentResource;
+import org.s_ramp.xmlns._2010.s_ramp.XsdDocument;
 
 /**
  * Unit test for the 
@@ -101,6 +103,37 @@ public class SrampAtomApiClientTest extends BaseResourceTest {
 	}
 
 	/**
+	 * Tests updating an artifact.
+	 * @throws Exception
+	 */
+	public void testUpdateArtifactMetaData() throws Exception {
+		SrampAtomApiClient client = new SrampAtomApiClient(generateURL("/s-ramp"));
+		URI uuid = null;
+		XsdDocument xsdDoc = null;
+		
+		// First, upload an artifact so we have some content to update
+		String artifactFileName = "PO.xsd";
+		InputStream is = this.getClass().getResourceAsStream("/sample-files/xsd/" + artifactFileName);
+		try {
+			Entry entry = client.uploadArtifact("xsd", "XsdDocument", is, artifactFileName);
+			Assert.assertNotNull(entry);
+			Assert.assertEquals(artifactFileName, entry.getTitle());
+			uuid = entry.getId();
+			xsdDoc = entry.getAnyOtherJAXBObject(XsdDocument.class);
+		} finally {
+			is.close();
+		}
+		
+		// Now update the description
+		xsdDoc.setDescription("** DESCRIPTION UPDATED **");
+		client.updateArtifactMetaData(xsdDoc);
+		
+		// Now verify
+		Entry entry = client.getFullArtifactEntry(ArtifactType.XsdDocument, uuid.toString());
+		Assert.assertEquals("** DESCRIPTION UPDATED **", entry.getSummary());
+	}
+
+	/**
 	 * Test method for {@link org.overlord.sramp.client.SrampAtomApiClient#query(java.lang.String, int, int, java.lang.String, boolean)}.
 	 */
 	@Test
@@ -130,7 +163,7 @@ public class SrampAtomApiClientTest extends BaseResourceTest {
 		}
 		Assert.assertTrue("Failed to find the artifact we just added!", uuidFound);
 	}
-
+	
 	/**
 	 * Test method for {@link org.overlord.sramp.client.SrampAtomApiClient#uploadArtifact(java.lang.String, java.lang.String, java.io.InputStream, java.lang.String)}.
 	 */


### PR DESCRIPTION
The s-ramp client can now update the meta-data for an existing artifact.
