### PR TITLE
(sramp-53) Improved error handling in JCR persistence layer

### DIFF
--- a/s-ramp-atom/src/main/java/org/overlord/sramp/atom/services/AdHocQueryResource.java
+++ b/s-ramp-atom/src/main/java/org/overlord/sramp/atom/services/AdHocQueryResource.java
@@ -144,11 +144,10 @@ public class AdHocQueryResource {
 				xpath = "/s-ramp/" + query;
 		}
 
-		QueryManager queryManager = QueryManagerFactory.newInstance();
-		SrampQuery srampQuery = queryManager.createQuery(xpath, orderBy, ascending);
 		ArtifactSet artifactSet = null;
-		
 		try {
+			QueryManager queryManager = QueryManagerFactory.newInstance();
+			SrampQuery srampQuery = queryManager.createQuery(xpath, orderBy, ascending);
 			artifactSet = srampQuery.executeQuery();
 			int startIdx = page * pageSize;
 			int endIdx = startIdx + pageSize - 1;

--- a/s-ramp-repository-jcr/src/main/java/org/overlord/sramp/repository/jcr/JCRNodeToArtifactFactory.java
+++ b/s-ramp-repository-jcr/src/main/java/org/overlord/sramp/repository/jcr/JCRNodeToArtifactFactory.java
@@ -19,7 +19,7 @@ import javax.jcr.Node;
 import javax.jcr.PathNotFoundException;
 
 import org.overlord.sramp.ArtifactType;
-import org.overlord.sramp.repository.DerivedArtifactsCreationException;
+import org.overlord.sramp.repository.RepositoryException;
 import org.overlord.sramp.repository.jcr.mapper.XmlModel;
 import org.overlord.sramp.repository.jcr.mapper.XsdModel;
 import org.s_ramp.xmlns._2010.s_ramp.BaseArtifactType;
@@ -57,19 +57,15 @@ public final class JCRNodeToArtifactFactory {
 	 * @param jcrNode a node in the JCR repo
 	 * @param artifactType the type of artifact represented by the {@link Node}
 	 * @return S-RAMP artifact
+	 * @throws RepositoryException 
 	 */
-	public static BaseArtifactType createArtifact(Node jcrNode, ArtifactType artifactType) {
-		// TODO I don't think XYZModel.getXYZDocument() should throw a DerivedArtifactsCreationException (something else maybe)
-        try {
-			if (artifactType == ArtifactType.XsdDocument) {
-			    return XsdModel.getXsdDocument(jcrNode);
-			} else if (artifactType == ArtifactType.XmlDocument) {
-			    return XmlModel.getXmlDocument(jcrNode);
-			} else {
-				return null;
-			}
-		} catch (DerivedArtifactsCreationException e) {
-			throw new RuntimeException(e);
+	public static BaseArtifactType createArtifact(Node jcrNode, ArtifactType artifactType) throws RepositoryException {
+		if (artifactType == ArtifactType.XsdDocument) {
+		    return XsdModel.getXsdDocument(jcrNode);
+		} else if (artifactType == ArtifactType.XmlDocument) {
+		    return XmlModel.getXmlDocument(jcrNode);
+		} else {
+			return null;
 		}
 	}
 

--- a/s-ramp-repository-jcr/src/main/java/org/overlord/sramp/repository/jcr/mapper/XmlModel.java
+++ b/s-ramp-repository-jcr/src/main/java/org/overlord/sramp/repository/jcr/mapper/XmlModel.java
@@ -16,32 +16,27 @@
 package org.overlord.sramp.repository.jcr.mapper;
 
 import javax.jcr.Node;
-import javax.jcr.PathNotFoundException;
-import javax.jcr.RepositoryException;
-import javax.jcr.ValueFormatException;
+import javax.xml.datatype.DatatypeConfigurationException;
 
-import org.overlord.sramp.repository.DerivedArtifactsCreationException;
+import org.overlord.sramp.repository.RepositoryException;
 import org.s_ramp.xmlns._2010.s_ramp.XmlDocument;
 
+/**
+ * Maps a JCR node to an S-RAMP artifact.  This class specifically handles XML artifacts.
+ */
 public class XmlModel extends DocumentArtifactModel {
 
     /**
-     * Input is the root node of the derived xsd data
-     * @throws DerivedArtifactsCreationException 
-     * @throws RepositoryException 
-     * @throws PathNotFoundException 
-     * @throws ValueFormatException 
+     * Input is the root node of the derived XML data.
+     * @param jcrNode
+     * @throws DatatypeConfigurationException
+     * @throws RepositoryException
      */
-    public static  XmlDocument getXmlDocument(Node derivedNode) throws DerivedArtifactsCreationException {
+    public static XmlDocument getXmlDocument(Node jcrNode) throws RepositoryException {
         XmlDocument xmlDocument = new XmlDocument();
-        
-        try {
-        	mapBaseArtifactMetaData(derivedNode, xmlDocument);
-        	mapDocumentArtifactMetaData(derivedNode, xmlDocument);
-        	mapXmlDocumentArtifactMetaData(derivedNode, xmlDocument);
-        } catch (Exception e) {
-            throw new DerivedArtifactsCreationException(e.getMessage(),e);
-        }
+    	mapBaseArtifactMetaData(jcrNode, xmlDocument);
+    	mapDocumentArtifactMetaData(jcrNode, xmlDocument);
+    	mapXmlDocumentArtifactMetaData(jcrNode, xmlDocument);
         return xmlDocument;
     }
 

--- a/s-ramp-repository-jcr/src/main/java/org/overlord/sramp/repository/jcr/mapper/XsdModel.java
+++ b/s-ramp-repository-jcr/src/main/java/org/overlord/sramp/repository/jcr/mapper/XsdModel.java
@@ -16,41 +16,37 @@
 package org.overlord.sramp.repository.jcr.mapper;
 
 import javax.jcr.Node;
-import javax.jcr.PathNotFoundException;
-import javax.jcr.RepositoryException;
-import javax.jcr.ValueFormatException;
 
-import org.overlord.sramp.repository.DerivedArtifactsCreationException;
+import org.overlord.sramp.repository.RepositoryException;
 import org.s_ramp.xmlns._2010.s_ramp.XsdDocument;
 
+/**
+ * Maps a JCR node to an S-RAMP artifact.  This class specifically handles XSD artifacts.
+ *
+ * @author eric.wittmann@redhat.com
+ */
 public class XsdModel extends XmlModel {
 
     /**
      * Input is the root node of the derived xsd data
-     * @throws DerivedArtifactsCreationException 
-     * @throws RepositoryException 
-     * @throws PathNotFoundException 
-     * @throws ValueFormatException 
+     * @param jcrNode
+     * @throws RepositoryException
      */
-    public static XsdDocument getXsdDocument(Node derivedNode) throws DerivedArtifactsCreationException {
+    public static XsdDocument getXsdDocument(Node jcrNode) throws RepositoryException {
         XsdDocument xsdDocument = new XsdDocument();
         
-        try {
-        	mapBaseArtifactMetaData(derivedNode, xsdDocument);
-        	mapDocumentArtifactMetaData(derivedNode, xsdDocument);
-        	mapXmlDocumentArtifactMetaData(derivedNode, xsdDocument);
-            
-            //TODO
-            //xsdDocument.getImportedXsds()
-            //xsdDocument.getIncludedXsds()
-            //xsdDocument.getRedefinedXsds()
-            //xsdDocument.getOtherAttributes()
-            //xsdDocument.getProperty()
-            //xsdDocument.getOtherAttributes()
-            //xsdDocument.getRelationship()
-        } catch (Exception e) {
-            throw new DerivedArtifactsCreationException(e.getMessage(),e);
-        }
+    	mapBaseArtifactMetaData(jcrNode, xsdDocument);
+    	mapDocumentArtifactMetaData(jcrNode, xsdDocument);
+    	mapXmlDocumentArtifactMetaData(jcrNode, xsdDocument);
+        
+        //TODO
+        //xsdDocument.getImportedXsds()
+        //xsdDocument.getIncludedXsds()
+        //xsdDocument.getRedefinedXsds()
+        //xsdDocument.getOtherAttributes()
+        //xsdDocument.getProperty()
+        //xsdDocument.getOtherAttributes()
+        //xsdDocument.getRelationship()
         
         return xsdDocument;
     }

--- a/s-ramp-repository-jcr/src/test/java/org/overlord/sramp/repository/jcr/JCRPersistenceTest.java
+++ b/s-ramp-repository-jcr/src/test/java/org/overlord/sramp/repository/jcr/JCRPersistenceTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 import org.overlord.sramp.ArtifactType;
 import org.overlord.sramp.repository.PersistenceFactory;
 import org.overlord.sramp.repository.PersistenceManager;
+import org.overlord.sramp.repository.RepositoryException;
 import org.s_ramp.xmlns._2010.s_ramp.BaseArtifactType;
 import org.s_ramp.xmlns._2010.s_ramp.Property;
 import org.s_ramp.xmlns._2010.s_ramp.XmlDocument;
@@ -70,7 +71,7 @@ public class JCRPersistenceTest {
 	 * XML is not yet up sequencing all the necessary artifacts.
 	 * @throws Exception
 	 */
-    @Test(expected=RuntimeException.class)
+    @Test(expected=RepositoryException.class)
     public void testSavePO_XML() throws Exception {
         String artifactFileName = "PO.xml";
         InputStream POXml = this.getClass().getResourceAsStream("/sample-files/xml/" + artifactFileName);

--- a/s-ramp-repository/src/main/java/org/overlord/sramp/repository/DerivedArtifacts.java
+++ b/s-ramp-repository/src/main/java/org/overlord/sramp/repository/DerivedArtifacts.java
@@ -34,6 +34,6 @@ public interface DerivedArtifacts {
      * @param artifact the original artifact
      */
     public Collection<? extends DerivedArtifactType> createDerivedArtifacts(ArtifactType artifactType, BaseArtifactType artifact) 
-    		throws DerivedArtifactsCreationException, UnsupportedFiletypeException;
+    		throws DerivedArtifactsCreationException;
 
 }

--- a/s-ramp-repository/src/main/java/org/overlord/sramp/repository/DerivedArtifactsCreationException.java
+++ b/s-ramp-repository/src/main/java/org/overlord/sramp/repository/DerivedArtifactsCreationException.java
@@ -15,24 +15,45 @@
  */
 package org.overlord.sramp.repository;
 
-public class DerivedArtifactsCreationException extends Exception {
+/**
+ * Exception thrown when a problem is discovered during indexing/sequencing of
+ * an s-ramp artifact (creating the derived artifacts for a given non-derived
+ * artifact).
+ */
+public class DerivedArtifactsCreationException extends RepositoryException {
 
     private static final long serialVersionUID = -1205817784608428279L;
 
+    /**
+     * Constructor.
+     */
     public DerivedArtifactsCreationException() {
         super();
     }
 
-    public DerivedArtifactsCreationException(String arg0, Throwable arg1) {
-        super(arg0, arg1);
+    /**
+     * Constructor.
+     * @param message
+     * @param rootCause
+     */
+    public DerivedArtifactsCreationException(String message, Throwable rootCause) {
+        super(message, rootCause);
     }
 
-    public DerivedArtifactsCreationException(String arg0) {
-        super(arg0);
+    /**
+     * Constructor.
+     * @param message
+     */
+    public DerivedArtifactsCreationException(String message) {
+        super(message);
     }
 
-    public DerivedArtifactsCreationException(Throwable arg0) {
-        super(arg0);
+    /**
+     * Constructor.
+     * @param rootCause
+     */
+    public DerivedArtifactsCreationException(Throwable rootCause) {
+        super(rootCause);
     }
 
 }

--- a/s-ramp-repository/src/main/java/org/overlord/sramp/repository/PersistenceManager.java
+++ b/s-ramp-repository/src/main/java/org/overlord/sramp/repository/PersistenceManager.java
@@ -32,23 +32,25 @@ public interface PersistenceManager {
 	 * @param name the name of the artifact
 	 * @param type the artifact type
 	 * @param content the artifact content
-	 * @throws UnsupportedFiletypeException
+	 * @throws RepositoryException
 	 */
-    public BaseArtifactType persistArtifact(String name, ArtifactType type, InputStream content) throws UnsupportedFiletypeException;
+    public BaseArtifactType persistArtifact(String name, ArtifactType type, InputStream content) throws RepositoryException;
     
     /**
      * Persists a single derived artifact.
      * @param artifact the derived artifact to persist
+	 * @throws RepositoryException
      */
-    public void persistDerivedArtifact(DerivedArtifactType artifact);
+    public void persistDerivedArtifact(DerivedArtifactType artifact) throws RepositoryException;
 
 	/**
 	 * Gets a previously persisted artifact by its UUID.
 	 * @param uuid the UUID of the s-ramp artifact
 	 * @param artifactType the type of the artifact
 	 * @return an instance of a {@link BaseArtifactType}
+	 * @throws RepositoryException
 	 */
-	public BaseArtifactType getArtifact(String uuid, ArtifactType type);
+	public BaseArtifactType getArtifact(String uuid, ArtifactType type) throws RepositoryException;
 
 	/**
 	 * Gets the content (media) for a previously persisted artifact by its UUID.  
@@ -58,23 +60,31 @@ public interface PersistenceManager {
 	 * @param uuid the S-RAMP uuid of the artifact.
 	 * @param artifactType the type of the artifact
 	 * @return an {@link InputStream} over the artifact content
+	 * @throws RepositoryException
 	 */
-	public InputStream getArtifactContent(String uuid, ArtifactType artifactType);
+	public InputStream getArtifactContent(String uuid, ArtifactType artifactType) throws RepositoryException;
 
 	/**
 	 * Updates a previously persisted artifact.  Note that this method only updates the meta data
 	 * of the artifact, not the content.  This will not create or delete any derived artifacts.
 	 * @param artifact the s-ramp artifact being updated
 	 * @param type the type of the artifact
+	 * @throws RepositoryException
 	 */
-	public void updateArtifact(BaseArtifactType artifact, ArtifactType type);
+	public void updateArtifact(BaseArtifactType artifact, ArtifactType type) throws RepositoryException;
 
 	/**
 	 * Gets a list of S-RAMP artifacts of the given type.
 	 * @param type the S-RAMP artifact type
 	 * @return a {@link List} of S-RAMP artifacts
+	 * @throws RepositoryException
 	 */
-	public List<BaseArtifactType> getArtifacts(ArtifactType type);
-    
+	public List<BaseArtifactType> getArtifacts(ArtifactType type) throws RepositoryException;
+
+	/**
+	 * TODO remove this
+	 * @param uuid
+	 * @param type
+	 */
     public void printArtifactGraph(String uuid, ArtifactType type);
 }

--- a/s-ramp-repository/src/main/java/org/overlord/sramp/repository/QueryManager.java
+++ b/s-ramp-repository/src/main/java/org/overlord/sramp/repository/QueryManager.java
@@ -46,15 +46,17 @@ public interface QueryManager {
 	 * @param orderByProperty property name to use when sorting
 	 * @param orderAscending whether to sort ascending
 	 * @return a new {@link SrampQuery} object
+	 * @throws RepositoryException
 	 */
-	public SrampQuery createQuery(String xpathTemplate, String orderByProperty, boolean orderAscending);
+	public SrampQuery createQuery(String xpathTemplate, String orderByProperty, boolean orderAscending) throws RepositoryException;
 
 	/**
 	 * Create an s-ramp query from the given xpath template.  No order-by hints are given,
 	 * so the s-ramp repository is free to return the artifacts in any arbitrary order.
 	 * @param xpathTemplate the templatized xpath
 	 * @return a new {@link SrampQuery} object
+	 * @throws RepositoryException
 	 */
-	public SrampQuery createQuery(String xpathTemplate);
+	public SrampQuery createQuery(String xpathTemplate) throws RepositoryException;
 
 }

--- a/s-ramp-repository/src/main/java/org/overlord/sramp/repository/RepositoryException.java
+++ b/s-ramp-repository/src/main/java/org/overlord/sramp/repository/RepositoryException.java
@@ -15,24 +15,43 @@
  */
 package org.overlord.sramp.repository;
 
+/**
+ * Exception thrown by the S-RAMP Repository.
+ */
 public class RepositoryException extends Exception {
 
     private static final long serialVersionUID = -1205817784608428279L;
 
+    /**
+     * Constructor.
+     */
     public RepositoryException() {
         super();
     }
 
-    public RepositoryException(String arg0, Throwable arg1) {
-        super(arg0, arg1);
+    /**
+     * Constructor.
+     * @param message
+     * @param rootCause
+     */
+    public RepositoryException(String message, Throwable rootCause) {
+        super(message, rootCause);
     }
 
-    public RepositoryException(String arg0) {
-        super(arg0);
+    /**
+     * Constructor.
+     * @param message
+     */
+    public RepositoryException(String message) {
+        super(message);
     }
 
-    public RepositoryException(Throwable arg0) {
-        super(arg0);
+    /**
+     * Constructor.
+     * @param rootCause
+     */
+    public RepositoryException(Throwable rootCause) {
+        super(rootCause);
     }
 
 }


### PR DESCRIPTION
Cleaned up the exception handling in the jcr persistence layer.  Errors
will now be wrapped in an s-ramp RepositoryException (or some other
appropriate exception, like DerivedArtifactCreationException) and
propagated (all the way to the UI when applicable).
