### PR TITLE
(sramp-61) Better artifact mime-type support

### DIFF
--- a/s-ramp-atom/src/main/java/org/overlord/sramp/atom/models/ArtifactToSummaryAtomEntryVisitor.java
+++ b/s-ramp-atom/src/main/java/org/overlord/sramp/atom/models/ArtifactToSummaryAtomEntryVisitor.java
@@ -102,8 +102,9 @@ public class ArtifactToSummaryAtomEntryVisitor extends ArtifactVisitorAdapter {
 			entry.setSummary(artifact.getDescription());
 
 			//TODO create URL Helper, obtain base URL from server
-			String atomLink = "http://localhost:8080/changeit/s-ramp/" + artifactType.getModel() + "/"
-					+ artifactType.getType() + "/" + artifact.getUuid();
+			String atomLink = "http://localhost:8080/changeit/s-ramp/"
+					+ artifactType.getArtifactType().getModel() + "/"
+					+ artifactType.getArtifactType().getType() + "/" + artifact.getUuid();
 			String mediaLink = atomLink + "/media";
 
 			// Original content can be accessed at /s-ramp/{model}/{artifact-type}/{uid}/media
@@ -137,14 +138,14 @@ public class ArtifactToSummaryAtomEntryVisitor extends ArtifactVisitorAdapter {
 
 			//category
 			Category typeCat = new Category();
-			typeCat.setTerm(artifactType.getType());
-			typeCat.setLabel(artifactType.getLabel());
+			typeCat.setTerm(artifactType.getArtifactType().getType());
+			typeCat.setLabel(artifactType.getArtifactType().getLabel());
 			typeCat.setScheme(new URI("x-s-ramp:2010:type"));
 			entry.getCategories().add(typeCat);
 
 			Category modelCat = new Category();
-			modelCat.setTerm(artifactType.getModel());
-			modelCat.setLabel(artifactType.getLabel());
+			modelCat.setTerm(artifactType.getArtifactType().getModel());
+			modelCat.setLabel(artifactType.getArtifactType().getLabel());
 			modelCat.setScheme(new URI("x-s-ramp:2010:model"));
 			entry.getCategories().add(modelCat);
 

--- a/s-ramp-client/src/main/java/org/overlord/sramp/client/SrampAtomApiClient.java
+++ b/s-ramp-client/src/main/java/org/overlord/sramp/client/SrampAtomApiClient.java
@@ -79,7 +79,7 @@ public class SrampAtomApiClient {
 	 */
 	public Entry getFullArtifactEntry(ArtifactType artifactType, String artifactUuid)
 			throws SrampClientException, SrampServerException {
-		return getFullArtifactEntry(artifactType.getModel(), artifactType.getType(), artifactUuid);
+		return getFullArtifactEntry(artifactType.getArtifactType().getModel(), artifactType.getArtifactType().getType(), artifactUuid);
 	}
 
 	/**
@@ -112,7 +112,7 @@ public class SrampAtomApiClient {
 	 */
 	public InputStream getArtifactContent(ArtifactType artifactType, String artifactUuid)
 			throws SrampClientException, SrampServerException {
-		return getArtifactContent(artifactType.getModel(), artifactType.getType(), artifactUuid);
+		return getArtifactContent(artifactType.getArtifactType().getModel(), artifactType.getArtifactType().getType(), artifactUuid);
 	}
 
 	/**
@@ -142,7 +142,8 @@ public class SrampAtomApiClient {
 	public Entry uploadArtifact(ArtifactType artifactType, InputStream content, String artifactFileName)
 			throws SrampClientException, SrampServerException {
 		try {
-			String atomUrl = String.format("%1$s/%2$s/%3$s", this.endpoint, artifactType.getModel(), artifactType.getType());
+			String atomUrl = String.format("%1$s/%2$s/%3$s", this.endpoint,
+					artifactType.getArtifactType().getModel(), artifactType.getArtifactType().getType());
 			ClientRequest request = new ClientRequest(atomUrl);
 			if (artifactFileName != null)
 				request.header("Slug", artifactFileName);
@@ -166,8 +167,8 @@ public class SrampAtomApiClient {
 	public void updateArtifactMetaData(BaseArtifactType artifact) throws SrampClientException {
 		try {
 			ArtifactType type = ArtifactType.valueOf(artifact);
-			String artifactModel = type.getModel();
-			String artifactType = type.getType();
+			String artifactModel = type.getArtifactType().getModel();
+			String artifactType = type.getArtifactType().getType();
 			String artifactUuid = artifact.getUuid();
 			String atomUrl = String.format("%1$s/%2$s/%3$s/%4$s", this.endpoint, artifactModel, artifactType, artifactUuid);
 			ClientRequest request = new ClientRequest(atomUrl);
@@ -193,8 +194,9 @@ public class SrampAtomApiClient {
 	public void updateArtifact(BaseArtifactType artifact, InputStream content) throws SrampClientException {
 		try {
 			ArtifactType type = ArtifactType.valueOf(artifact);
-			String artifactModel = type.getModel();
-			String artifactType = type.getType();
+
+			String artifactModel = type.getArtifactType().getModel();
+			String artifactType = type.getArtifactType().getType();
 			String artifactUuid = artifact.getUuid();
 			String atomUrl = String.format("%1$s/%2$s/%3$s/%4$s/media", this.endpoint, artifactModel, artifactType, artifactUuid);
 			ClientRequest request = new ClientRequest(atomUrl);

--- a/s-ramp-core/src/main/java/org/overlord/sramp/ArtifactType.java
+++ b/s-ramp-core/src/main/java/org/overlord/sramp/ArtifactType.java
@@ -17,186 +17,41 @@ package org.overlord.sramp;
 
 import java.lang.reflect.Method;
 
-import org.s_ramp.xmlns._2010.s_ramp.Actor;
 import org.s_ramp.xmlns._2010.s_ramp.Artifact;
-import org.s_ramp.xmlns._2010.s_ramp.AttributeDeclaration;
 import org.s_ramp.xmlns._2010.s_ramp.BaseArtifactEnum;
 import org.s_ramp.xmlns._2010.s_ramp.BaseArtifactType;
-import org.s_ramp.xmlns._2010.s_ramp.Binding;
-import org.s_ramp.xmlns._2010.s_ramp.BindingOperation;
-import org.s_ramp.xmlns._2010.s_ramp.BindingOperationFault;
-import org.s_ramp.xmlns._2010.s_ramp.BindingOperationInput;
-import org.s_ramp.xmlns._2010.s_ramp.BindingOperationOutput;
-import org.s_ramp.xmlns._2010.s_ramp.Choreography;
-import org.s_ramp.xmlns._2010.s_ramp.ChoreographyProcess;
-import org.s_ramp.xmlns._2010.s_ramp.Collaboration;
-import org.s_ramp.xmlns._2010.s_ramp.CollaborationProcess;
-import org.s_ramp.xmlns._2010.s_ramp.ComplexTypeDeclaration;
-import org.s_ramp.xmlns._2010.s_ramp.Composition;
-import org.s_ramp.xmlns._2010.s_ramp.Effect;
-import org.s_ramp.xmlns._2010.s_ramp.Element;
-import org.s_ramp.xmlns._2010.s_ramp.ElementDeclaration;
-import org.s_ramp.xmlns._2010.s_ramp.Event;
-import org.s_ramp.xmlns._2010.s_ramp.Fault;
-import org.s_ramp.xmlns._2010.s_ramp.InformationType;
-import org.s_ramp.xmlns._2010.s_ramp.Message;
-import org.s_ramp.xmlns._2010.s_ramp.Operation;
-import org.s_ramp.xmlns._2010.s_ramp.OperationInput;
-import org.s_ramp.xmlns._2010.s_ramp.OperationOutput;
-import org.s_ramp.xmlns._2010.s_ramp.Orchestration;
-import org.s_ramp.xmlns._2010.s_ramp.OrchestrationProcess;
-import org.s_ramp.xmlns._2010.s_ramp.Organization;
-import org.s_ramp.xmlns._2010.s_ramp.Part;
-import org.s_ramp.xmlns._2010.s_ramp.Policy;
-import org.s_ramp.xmlns._2010.s_ramp.PolicyAttachment;
-import org.s_ramp.xmlns._2010.s_ramp.PolicyDocument;
-import org.s_ramp.xmlns._2010.s_ramp.PolicyExpression;
-import org.s_ramp.xmlns._2010.s_ramp.PolicySubject;
-import org.s_ramp.xmlns._2010.s_ramp.Port;
-import org.s_ramp.xmlns._2010.s_ramp.PortType;
-import org.s_ramp.xmlns._2010.s_ramp.Service;
-import org.s_ramp.xmlns._2010.s_ramp.ServiceComposition;
-import org.s_ramp.xmlns._2010.s_ramp.ServiceContract;
-import org.s_ramp.xmlns._2010.s_ramp.ServiceEndpoint;
-import org.s_ramp.xmlns._2010.s_ramp.ServiceInstance;
-import org.s_ramp.xmlns._2010.s_ramp.ServiceInterface;
-import org.s_ramp.xmlns._2010.s_ramp.ServiceOperation;
-import org.s_ramp.xmlns._2010.s_ramp.SimpleTypeDeclaration;
-import org.s_ramp.xmlns._2010.s_ramp.SoapAddress;
-import org.s_ramp.xmlns._2010.s_ramp.SoapBinding;
-import org.s_ramp.xmlns._2010.s_ramp.Task;
-import org.s_ramp.xmlns._2010.s_ramp.UserDefinedArtifactType;
-import org.s_ramp.xmlns._2010.s_ramp.WsdlDocument;
-import org.s_ramp.xmlns._2010.s_ramp.WsdlExtension;
-import org.s_ramp.xmlns._2010.s_ramp.WsdlService;
-import org.s_ramp.xmlns._2010.s_ramp.XmlDocument;
-import org.s_ramp.xmlns._2010.s_ramp.XsdDocument;
 
 /**
  * An enum representing all of the Artifact Types defined by S-RAMP.
  *
  * @author eric.wittmann@redhat.com
  */
-public enum ArtifactType {
+public class ArtifactType {
 
-	// Core
-	XmlDocument("core", "XML Document", XmlDocument.class, "application/xml", BaseArtifactEnum.XML_DOCUMENT),
-	// XSD
-	XsdDocument("xsd", "XML Schema", XsdDocument.class, "application/xml", BaseArtifactEnum.XSD_DOCUMENT),
-	AttributeDeclaration("xsd", "XML Schema Attribute Declaration", AttributeDeclaration.class, null, BaseArtifactEnum.ATTRIBUTE_DECLARATION),
-	ElementDeclaration("xsd", "XML Schema Element Declaration", ElementDeclaration.class, null, BaseArtifactEnum.ELEMENT_DECLARATION),
-	SimpleTypeDeclaration("xsd", "XML Schema Simple Type Declaration", SimpleTypeDeclaration.class, null, BaseArtifactEnum.SIMPLE_TYPE_DECLARATION),
-	ComplexTypeDeclaration("xsd", "XML Schema Complex Type Declaration", ComplexTypeDeclaration.class, null, BaseArtifactEnum.COMPLEX_TYPE_DECLARATION),
-	// Policy
-	PolicyDocument("policy", "Policy", PolicyDocument.class, "application/xml", BaseArtifactEnum.POLICY_DOCUMENT),
-	PolicyExpression("policy", "Policy Expression", PolicyExpression.class, null, BaseArtifactEnum.POLICY_EXPRESSION),
-	PolicyAttachment("policy", "Policy Attachment", PolicyAttachment.class, null, BaseArtifactEnum.POLICY_ATTACHMENT),
-	// SOAP
-	SoapAddress("soapWsdl", "SOAP Address", SoapAddress.class, null, BaseArtifactEnum.SOAP_ADDRESS),
-	SoapBinding("soapWsdl", "SOAP Binding", SoapBinding.class, null, BaseArtifactEnum.SOAP_BINDING),
-	// WSDL
-	WsdlDocument("wsdl", "WSDL", WsdlDocument.class, "application/xml", BaseArtifactEnum.WSDL_DOCUMENT),
-	WsdlService("wsdl", "WSDL Service", WsdlService.class, null, BaseArtifactEnum.WSDL_SERVICE),
-	Port("wsdl", "WSDL Port", Port.class, null, BaseArtifactEnum.PORT),
-	WsdlExtension("wsdl", "WSDL Extension", WsdlExtension.class, null, BaseArtifactEnum.WSDL_EXTENSION),
-	Part("wsdl", "WSDL Part", Part.class, null, BaseArtifactEnum.PART),
-	Message("wsdl", "WSDL Message", Message.class, null, BaseArtifactEnum.MESSAGE),
-	Fault("wsdl", "WSDL Fault", Fault.class, null, BaseArtifactEnum.FAULT),
-	PortType("wsdl", "WSDL Port Type", PortType.class, null, BaseArtifactEnum.PORT_TYPE),
-	Operation("wsdl", "WSDL Operation", Operation.class, null, BaseArtifactEnum.OPERATION),
-	OperationInput("wsdl", "WSDL Operation Input", OperationInput.class, null, BaseArtifactEnum.OPERATION_INPUT),
-	OperationOutput("wsdl", "WSDL Operation Output", OperationOutput.class, null, BaseArtifactEnum.OPERATION_OUTPUT),
-	Binding("wsdl", "WSDL Binding", Binding.class, null, BaseArtifactEnum.BINDING),
-	BindingOperation("wsdl", "WSDL Binding Operation", BindingOperation.class, null, BaseArtifactEnum.BINDING_OPERATION),
-	BindingOperationInput("wsdl", "WSDL Binding Operation Input", BindingOperationInput.class, null, BaseArtifactEnum.BINDING_OPERATION_INPUT),
-	BindingOperationOutput("wsdl", "WSDL Binding Operation Output", BindingOperationOutput.class, null, BaseArtifactEnum.BINDING_OPERATION_OUTPUT),
-	BindingOperationFault("wsdl", "WSDL Binding Operation Fault", BindingOperationFault.class, null, BaseArtifactEnum.BINDING_OPERATION_FAULT),
-	// Service Implementation
-	Organization("serviceImplementation", "Organization", Organization.class, null, BaseArtifactEnum.ORGANIZATION),
-	ServiceEndpoint("serviceImplementation", "Service Endpoint", ServiceEndpoint.class, null, BaseArtifactEnum.SERVICE_ENDPOINT),
-	ServiceInstance("serviceImplementation", "Service Instance", ServiceInstance.class, null, BaseArtifactEnum.SERVICE_INSTANCE),
-	ServiceOperation("serviceImplementation", "Service Operation", ServiceOperation.class, null, BaseArtifactEnum.SERVICE_OPERATION),
-	// User Defined
-	UserDefined("user", "User Defined", UserDefinedArtifactType.class, null, BaseArtifactEnum.USER_DEFINED_ARTIFACT_TYPE), // TODO how are user defined types contributed/registered?
-	// SOA
-	HumanActor("soa", "SOA Human Actor", Actor.class, null, BaseArtifactEnum.ACTOR),
-	Choreography("soa", "SOA Choreography", Choreography.class, null, BaseArtifactEnum.CHOREOGRAPHY),
-	ChoreographyProcess("soa", "SOA Choreography Process", ChoreographyProcess.class, null, BaseArtifactEnum.CHOREOGRAPHY_PROCESS),
-	Collaboration("soa", "SOA Collaboration", Collaboration.class, null, BaseArtifactEnum.COLLABORATION),
-	CollaborationProcess("soa", "SOA Collaboration Process", CollaborationProcess.class, null, BaseArtifactEnum.COLLABORATION_PROCESS),
-	Composition("soa", "SOA Composition", Composition.class, null, BaseArtifactEnum.COMPOSITION),
-	Effect("soa", "SOA Effect", Effect.class, null, BaseArtifactEnum.EFFECT),
-	Element("soa", "SOA Element", Element.class, null, BaseArtifactEnum.ELEMENT),
-	Event("soa", "SOA Event", Event.class, null, BaseArtifactEnum.EVENT),
-	InformationType("soa", "SOA Information Type", InformationType.class, null, BaseArtifactEnum.INFORMATION_TYPE),
-	Orchestration("soa", "SOA Orchestration", Orchestration.class, null, BaseArtifactEnum.ORCHESTRATION),
-	OrchestrationProcess("soa", "SOA Orchestration Process", OrchestrationProcess.class, null, BaseArtifactEnum.ORCHESTRATION_PROCESS),
-	Policy("soa", "SOA Policy", Policy.class, null, BaseArtifactEnum.POLICY),
-	PolicySubject("soa", "SOA Policy Subject", PolicySubject.class, null, BaseArtifactEnum.POLICY_SUBJECT),
-	Process("soa", "SOA Process", org.s_ramp.xmlns._2010.s_ramp.Process.class, null, BaseArtifactEnum.PROCESS),
-	Service("soa", "SOA Service", Service.class, null, BaseArtifactEnum.SERVICE),
-	ServiceContract("soa", "SOA Service Contract", ServiceContract.class, null, BaseArtifactEnum.SERVICE_CONTRACT),
-	ServiceComposition("soa", "SOA Service Composition", ServiceComposition.class, null, BaseArtifactEnum.SERVICE_COMPOSITION),
-	ServiceInterface("soa", "SOA Service Interface", ServiceInterface.class, null, BaseArtifactEnum.SERVICE_INTERFACE),
-	System("soa", "SOA System", org.s_ramp.xmlns._2010.s_ramp.System.class, null, BaseArtifactEnum.SYSTEM),
-	Task("soa", "SOA Task", Task.class, null, BaseArtifactEnum.TASK)
-	;
+	public static final ArtifactType Document = new ArtifactType(ArtifactTypeEnum.Document, "application/octet-stream");
+	public static final ArtifactType XmlDocument = new ArtifactType(ArtifactTypeEnum.XmlDocument, "application/xml");
+	public static final ArtifactType XsdDocument = new ArtifactType(ArtifactTypeEnum.XsdDocument, "application/xml");
+	public static final ArtifactType WsdlDocument = new ArtifactType(ArtifactTypeEnum.WsdlDocument, "application/xml");
 
-	private final String model;
-	private final String label;
-	private final Class<? extends BaseArtifactType> typeClass;
-    private final String mimeType;
-    private final BaseArtifactEnum apiType;
+	private ArtifactTypeEnum artifactType;
+	private String mimeType;
 
 	/**
 	 * Constructor.
-	 * @param model the S-RAMP Artifact Model that this Artifact Type is a part of
-	 * @param label a human friendly label for the artifact type
-	 * @param typeClass the class that implements this Artifact Type
-	 * @param mimeType the mime-type of the artifact
+	 * @param artifactType
+	 * @param mimeType
 	 */
-	private ArtifactType(String model, String label, Class<? extends BaseArtifactType> typeClass,
-			String mimeType, BaseArtifactEnum apiType) {
-		this.model = model;
-		this.label = label;
-		this.typeClass = typeClass;
-		this.mimeType = mimeType;
-		this.apiType = apiType;
-	}
-
-	/**
-	 * @return the artifact model
-	 */
-	public String getModel() {
-		return model;
-	}
-
-	/**
-	 * @return the artifact type
-	 */
-	public String getType() {
-		return name();
-	}
-
-	/**
-	 * @return the label
-	 */
-	public String getLabel() {
-		return label;
-	}
-
-	/**
-	 * @return the mimeType
-	 */
-	public String getMimeType() {
-		return mimeType;
-	}
-
-	/**
-	 * @return the s-ramp API type
-	 */
-	public BaseArtifactEnum getApiType() {
-		return apiType;
+	private ArtifactType(ArtifactTypeEnum artifactType, String mimeType) {
+		setArtifactType(artifactType);
+		// Might need something more interesting than this in the future.
+		if (mimeType == null) {
+			if (artifactType == ArtifactTypeEnum.Document) {
+				mimeType = "application/octet-stream";
+			} else {
+				mimeType = "application/xml";
+			}
+		}
+		setMimeType(mimeType);
 	}
 
 	/**
@@ -206,18 +61,20 @@ public enum ArtifactType {
 	 */
 	public BaseArtifactType unwrap(Artifact artifactWrapper) {
 		try {
-			Method method = Artifact.class.getMethod("get" + this.name());
+			Method method = Artifact.class.getMethod("get" + getArtifactType().getType());
 			return (BaseArtifactType) method.invoke(artifactWrapper);
 		} catch (Exception e) {
-			throw new RuntimeException("Failed to unwrap artifact for type: " + this.name(), e);
+			throw new RuntimeException("Failed to unwrap artifact for type: " + getArtifactType().getType(), e);
 		}
 	}
 
 	/**
-	 * @return the typeClass
+	 * Figures out the artifact type (enum) from the given S-RAMP artifact type string.
+	 * @param artifactType
 	 */
-	public Class<? extends BaseArtifactType> getTypeClass() {
-		return typeClass;
+	public static ArtifactType valueOf(String artifactType) {
+		ArtifactTypeEnum artifactTypeEnum = ArtifactTypeEnum.valueOf(artifactType);
+		return new ArtifactType(artifactTypeEnum, null);
 	}
 
 	/**
@@ -229,10 +86,10 @@ public enum ArtifactType {
 		if (apiType != null) {
 			return valueOf(apiType);
 		}
-		ArtifactType[] values = values();
-		for (ArtifactType artifactType : values) {
+		ArtifactTypeEnum[] values = ArtifactTypeEnum.values();
+		for (ArtifactTypeEnum artifactType : values) {
 			if (artifactType.getTypeClass().equals(artifact.getClass())) {
-				return artifactType;
+				return new ArtifactType(artifactType, null);
 			}
 		}
 		throw new RuntimeException("Could not determine Artifact Type from artifact class: " + artifact.getClass());
@@ -243,13 +100,41 @@ public enum ArtifactType {
 	 * @param apiType
 	 */
 	public static ArtifactType valueOf(BaseArtifactEnum apiType) {
-		ArtifactType[] values = values();
-		for (ArtifactType artifactType : values) {
+		ArtifactTypeEnum[] values = ArtifactTypeEnum.values();
+		for (ArtifactTypeEnum artifactType : values) {
 			if (artifactType.getApiType() == apiType) {
-				return artifactType;
+				return new ArtifactType(artifactType, null);
 			}
 		}
 		throw new RuntimeException("Could not determine Artifact Type from S-RAMP API type: " + apiType.value());
+	}
+
+	/**
+	 * @return the artifactType
+	 */
+	public ArtifactTypeEnum getArtifactType() {
+		return artifactType;
+	}
+
+	/**
+	 * @param artifactType the artifactType to set
+	 */
+	public void setArtifactType(ArtifactTypeEnum artifactType) {
+		this.artifactType = artifactType;
+	}
+
+	/**
+	 * @return the mimeType
+	 */
+	public String getMimeType() {
+		return mimeType;
+	}
+
+	/**
+	 * @param mimeType the mimeType to set
+	 */
+	public void setMimeType(String mimeType) {
+		this.mimeType = mimeType;
 	}
 
 }

--- a/s-ramp-core/src/main/java/org/overlord/sramp/ArtifactTypeEnum.java
+++ b/s-ramp-core/src/main/java/org/overlord/sramp/ArtifactTypeEnum.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2012 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.overlord.sramp;
+
+import java.lang.reflect.Method;
+
+import org.s_ramp.xmlns._2010.s_ramp.Actor;
+import org.s_ramp.xmlns._2010.s_ramp.Artifact;
+import org.s_ramp.xmlns._2010.s_ramp.AttributeDeclaration;
+import org.s_ramp.xmlns._2010.s_ramp.BaseArtifactEnum;
+import org.s_ramp.xmlns._2010.s_ramp.BaseArtifactType;
+import org.s_ramp.xmlns._2010.s_ramp.Binding;
+import org.s_ramp.xmlns._2010.s_ramp.BindingOperation;
+import org.s_ramp.xmlns._2010.s_ramp.BindingOperationFault;
+import org.s_ramp.xmlns._2010.s_ramp.BindingOperationInput;
+import org.s_ramp.xmlns._2010.s_ramp.BindingOperationOutput;
+import org.s_ramp.xmlns._2010.s_ramp.Choreography;
+import org.s_ramp.xmlns._2010.s_ramp.ChoreographyProcess;
+import org.s_ramp.xmlns._2010.s_ramp.Collaboration;
+import org.s_ramp.xmlns._2010.s_ramp.CollaborationProcess;
+import org.s_ramp.xmlns._2010.s_ramp.ComplexTypeDeclaration;
+import org.s_ramp.xmlns._2010.s_ramp.Composition;
+import org.s_ramp.xmlns._2010.s_ramp.Document;
+import org.s_ramp.xmlns._2010.s_ramp.Effect;
+import org.s_ramp.xmlns._2010.s_ramp.Element;
+import org.s_ramp.xmlns._2010.s_ramp.ElementDeclaration;
+import org.s_ramp.xmlns._2010.s_ramp.Event;
+import org.s_ramp.xmlns._2010.s_ramp.Fault;
+import org.s_ramp.xmlns._2010.s_ramp.InformationType;
+import org.s_ramp.xmlns._2010.s_ramp.Message;
+import org.s_ramp.xmlns._2010.s_ramp.Operation;
+import org.s_ramp.xmlns._2010.s_ramp.OperationInput;
+import org.s_ramp.xmlns._2010.s_ramp.OperationOutput;
+import org.s_ramp.xmlns._2010.s_ramp.Orchestration;
+import org.s_ramp.xmlns._2010.s_ramp.OrchestrationProcess;
+import org.s_ramp.xmlns._2010.s_ramp.Organization;
+import org.s_ramp.xmlns._2010.s_ramp.Part;
+import org.s_ramp.xmlns._2010.s_ramp.Policy;
+import org.s_ramp.xmlns._2010.s_ramp.PolicyAttachment;
+import org.s_ramp.xmlns._2010.s_ramp.PolicyDocument;
+import org.s_ramp.xmlns._2010.s_ramp.PolicyExpression;
+import org.s_ramp.xmlns._2010.s_ramp.PolicySubject;
+import org.s_ramp.xmlns._2010.s_ramp.Port;
+import org.s_ramp.xmlns._2010.s_ramp.PortType;
+import org.s_ramp.xmlns._2010.s_ramp.Service;
+import org.s_ramp.xmlns._2010.s_ramp.ServiceComposition;
+import org.s_ramp.xmlns._2010.s_ramp.ServiceContract;
+import org.s_ramp.xmlns._2010.s_ramp.ServiceEndpoint;
+import org.s_ramp.xmlns._2010.s_ramp.ServiceInstance;
+import org.s_ramp.xmlns._2010.s_ramp.ServiceInterface;
+import org.s_ramp.xmlns._2010.s_ramp.ServiceOperation;
+import org.s_ramp.xmlns._2010.s_ramp.SimpleTypeDeclaration;
+import org.s_ramp.xmlns._2010.s_ramp.SoapAddress;
+import org.s_ramp.xmlns._2010.s_ramp.SoapBinding;
+import org.s_ramp.xmlns._2010.s_ramp.Task;
+import org.s_ramp.xmlns._2010.s_ramp.UserDefinedArtifactType;
+import org.s_ramp.xmlns._2010.s_ramp.WsdlDocument;
+import org.s_ramp.xmlns._2010.s_ramp.WsdlExtension;
+import org.s_ramp.xmlns._2010.s_ramp.WsdlService;
+import org.s_ramp.xmlns._2010.s_ramp.XmlDocument;
+import org.s_ramp.xmlns._2010.s_ramp.XsdDocument;
+
+/**
+ * An enum representing all of the Artifact Types defined by S-RAMP.
+ *
+ * @author eric.wittmann@redhat.com
+ */
+public enum ArtifactTypeEnum {
+
+	// Core
+	Document("core", "Document", Document.class, BaseArtifactEnum.DOCUMENT),
+	XmlDocument("core", "XML Document", XmlDocument.class, BaseArtifactEnum.XML_DOCUMENT),
+	// XSD
+	XsdDocument("xsd", "XML Schema", XsdDocument.class, BaseArtifactEnum.XSD_DOCUMENT),
+	AttributeDeclaration("xsd", "XML Schema Attribute Declaration", AttributeDeclaration.class, BaseArtifactEnum.ATTRIBUTE_DECLARATION),
+	ElementDeclaration("xsd", "XML Schema Element Declaration", ElementDeclaration.class, BaseArtifactEnum.ELEMENT_DECLARATION),
+	SimpleTypeDeclaration("xsd", "XML Schema Simple Type Declaration", SimpleTypeDeclaration.class, BaseArtifactEnum.SIMPLE_TYPE_DECLARATION),
+	ComplexTypeDeclaration("xsd", "XML Schema Complex Type Declaration", ComplexTypeDeclaration.class, BaseArtifactEnum.COMPLEX_TYPE_DECLARATION),
+	// Policy
+	PolicyDocument("policy", "Policy", PolicyDocument.class, BaseArtifactEnum.POLICY_DOCUMENT),
+	PolicyExpression("policy", "Policy Expression", PolicyExpression.class, BaseArtifactEnum.POLICY_EXPRESSION),
+	PolicyAttachment("policy", "Policy Attachment", PolicyAttachment.class, BaseArtifactEnum.POLICY_ATTACHMENT),
+	// SOAP
+	SoapAddress("soapWsdl", "SOAP Address", SoapAddress.class, BaseArtifactEnum.SOAP_ADDRESS),
+	SoapBinding("soapWsdl", "SOAP Binding", SoapBinding.class, BaseArtifactEnum.SOAP_BINDING),
+	// WSDL
+	WsdlDocument("wsdl", "WSDL", WsdlDocument.class, BaseArtifactEnum.WSDL_DOCUMENT),
+	WsdlService("wsdl", "WSDL Service", WsdlService.class, BaseArtifactEnum.WSDL_SERVICE),
+	Port("wsdl", "WSDL Port", Port.class, BaseArtifactEnum.PORT),
+	WsdlExtension("wsdl", "WSDL Extension", WsdlExtension.class, BaseArtifactEnum.WSDL_EXTENSION),
+	Part("wsdl", "WSDL Part", Part.class, BaseArtifactEnum.PART),
+	Message("wsdl", "WSDL Message", Message.class, BaseArtifactEnum.MESSAGE),
+	Fault("wsdl", "WSDL Fault", Fault.class, BaseArtifactEnum.FAULT),
+	PortType("wsdl", "WSDL Port Type", PortType.class, BaseArtifactEnum.PORT_TYPE),
+	Operation("wsdl", "WSDL Operation", Operation.class, BaseArtifactEnum.OPERATION),
+	OperationInput("wsdl", "WSDL Operation Input", OperationInput.class, BaseArtifactEnum.OPERATION_INPUT),
+	OperationOutput("wsdl", "WSDL Operation Output", OperationOutput.class, BaseArtifactEnum.OPERATION_OUTPUT),
+	Binding("wsdl", "WSDL Binding", Binding.class, BaseArtifactEnum.BINDING),
+	BindingOperation("wsdl", "WSDL Binding Operation", BindingOperation.class, BaseArtifactEnum.BINDING_OPERATION),
+	BindingOperationInput("wsdl", "WSDL Binding Operation Input", BindingOperationInput.class, BaseArtifactEnum.BINDING_OPERATION_INPUT),
+	BindingOperationOutput("wsdl", "WSDL Binding Operation Output", BindingOperationOutput.class, BaseArtifactEnum.BINDING_OPERATION_OUTPUT),
+	BindingOperationFault("wsdl", "WSDL Binding Operation Fault", BindingOperationFault.class, BaseArtifactEnum.BINDING_OPERATION_FAULT),
+	// Service Implementation
+	Organization("serviceImplementation", "Organization", Organization.class, BaseArtifactEnum.ORGANIZATION),
+	ServiceEndpoint("serviceImplementation", "Service Endpoint", ServiceEndpoint.class, BaseArtifactEnum.SERVICE_ENDPOINT),
+	ServiceInstance("serviceImplementation", "Service Instance", ServiceInstance.class, BaseArtifactEnum.SERVICE_INSTANCE),
+	ServiceOperation("serviceImplementation", "Service Operation", ServiceOperation.class, BaseArtifactEnum.SERVICE_OPERATION),
+	// User Defined
+	UserDefined("user", "User Defined", UserDefinedArtifactType.class, BaseArtifactEnum.USER_DEFINED_ARTIFACT_TYPE), // TODO how are user defined types contributed/registered?
+	// SOA
+	HumanActor("soa", "SOA Human Actor", Actor.class, BaseArtifactEnum.ACTOR),
+	Choreography("soa", "SOA Choreography", Choreography.class, BaseArtifactEnum.CHOREOGRAPHY),
+	ChoreographyProcess("soa", "SOA Choreography Process", ChoreographyProcess.class, BaseArtifactEnum.CHOREOGRAPHY_PROCESS),
+	Collaboration("soa", "SOA Collaboration", Collaboration.class, BaseArtifactEnum.COLLABORATION),
+	CollaborationProcess("soa", "SOA Collaboration Process", CollaborationProcess.class, BaseArtifactEnum.COLLABORATION_PROCESS),
+	Composition("soa", "SOA Composition", Composition.class, BaseArtifactEnum.COMPOSITION),
+	Effect("soa", "SOA Effect", Effect.class, BaseArtifactEnum.EFFECT),
+	Element("soa", "SOA Element", Element.class, BaseArtifactEnum.ELEMENT),
+	Event("soa", "SOA Event", Event.class, BaseArtifactEnum.EVENT),
+	InformationType("soa", "SOA Information Type", InformationType.class, BaseArtifactEnum.INFORMATION_TYPE),
+	Orchestration("soa", "SOA Orchestration", Orchestration.class, BaseArtifactEnum.ORCHESTRATION),
+	OrchestrationProcess("soa", "SOA Orchestration Process", OrchestrationProcess.class, BaseArtifactEnum.ORCHESTRATION_PROCESS),
+	Policy("soa", "SOA Policy", Policy.class, BaseArtifactEnum.POLICY),
+	PolicySubject("soa", "SOA Policy Subject", PolicySubject.class, BaseArtifactEnum.POLICY_SUBJECT),
+	Process("soa", "SOA Process", org.s_ramp.xmlns._2010.s_ramp.Process.class, BaseArtifactEnum.PROCESS),
+	Service("soa", "SOA Service", Service.class, BaseArtifactEnum.SERVICE),
+	ServiceContract("soa", "SOA Service Contract", ServiceContract.class, BaseArtifactEnum.SERVICE_CONTRACT),
+	ServiceComposition("soa", "SOA Service Composition", ServiceComposition.class, BaseArtifactEnum.SERVICE_COMPOSITION),
+	ServiceInterface("soa", "SOA Service Interface", ServiceInterface.class, BaseArtifactEnum.SERVICE_INTERFACE),
+	System("soa", "SOA System", org.s_ramp.xmlns._2010.s_ramp.System.class, BaseArtifactEnum.SYSTEM),
+	Task("soa", "SOA Task", Task.class, BaseArtifactEnum.TASK)
+	;
+
+	private final String model;
+	private final String label;
+	private final Class<? extends BaseArtifactType> typeClass;
+    private final BaseArtifactEnum apiType;
+
+	/**
+	 * Constructor.
+	 * @param model the S-RAMP Artifact Model that this Artifact Type is a part of
+	 * @param label a human friendly label for the artifact type
+	 * @param typeClass the class that implements this Artifact Type
+	 * @param apiType the type from the s-ramp API
+	 */
+	private ArtifactTypeEnum(String model, String label, Class<? extends BaseArtifactType> typeClass,
+			BaseArtifactEnum apiType) {
+		this.model = model;
+		this.label = label;
+		this.typeClass = typeClass;
+		this.apiType = apiType;
+	}
+
+	/**
+	 * @return the artifact model
+	 */
+	public String getModel() {
+		return model;
+	}
+
+	/**
+	 * @return the artifact type
+	 */
+	public String getType() {
+		return name();
+	}
+
+	/**
+	 * @return the label
+	 */
+	public String getLabel() {
+		return label;
+	}
+
+	/**
+	 * @return the s-ramp API type
+	 */
+	public BaseArtifactEnum getApiType() {
+		return apiType;
+	}
+
+	/**
+	 * Called to unwrap the S-RAMP artifact from its wrapper.
+	 * @param artifactWrapper the S-RAMP artifact wrapper
+	 * @return the specific artifact based on type
+	 */
+	public BaseArtifactType unwrap(Artifact artifactWrapper) {
+		try {
+			Method method = Artifact.class.getMethod("get" + this.name());
+			return (BaseArtifactType) method.invoke(artifactWrapper);
+		} catch (Exception e) {
+			throw new RuntimeException("Failed to unwrap artifact for type: " + this.name(), e);
+		}
+	}
+
+	/**
+	 * @return the typeClass
+	 */
+	public Class<? extends BaseArtifactType> getTypeClass() {
+		return typeClass;
+	}
+
+	/**
+	 * Figures out the type from the artifact instance.
+	 * @param artifact
+	 */
+	public static ArtifactTypeEnum valueOf(BaseArtifactType artifact) {
+		BaseArtifactEnum apiType = artifact.getArtifactType();
+		if (apiType != null) {
+			return valueOf(apiType);
+		}
+		ArtifactTypeEnum[] values = values();
+		for (ArtifactTypeEnum artifactType : values) {
+			if (artifactType.getTypeClass().equals(artifact.getClass())) {
+				return artifactType;
+			}
+		}
+		throw new RuntimeException("Could not determine Artifact Type from artifact class: " + artifact.getClass());
+	}
+
+	/**
+	 * Figures out the type from the s-ramp API type.
+	 * @param apiType
+	 */
+	public static ArtifactTypeEnum valueOf(BaseArtifactEnum apiType) {
+		ArtifactTypeEnum[] values = values();
+		for (ArtifactTypeEnum artifactType : values) {
+			if (artifactType.getApiType() == apiType) {
+				return artifactType;
+			}
+		}
+		throw new RuntimeException("Could not determine Artifact Type from S-RAMP API type: " + apiType.value());
+	}
+
+}

--- a/s-ramp-core/src/main/java/org/overlord/sramp/query/xpath/XPathParser.java
+++ b/s-ramp-core/src/main/java/org/overlord/sramp/query/xpath/XPathParser.java
@@ -3,14 +3,14 @@
  * See the COPYRIGHT.txt file distributed with this work for information
  * regarding copyright ownership.  Some portions may be licensed
  * to Red Hat, Inc. under one or more contributor license agreements.
- * See the AUTHORS.txt file in the distribution for a full listing of 
+ * See the AUTHORS.txt file in the distribution for a full listing of
  * individual contributors.
  *
  * ModeShape is free software. Unless otherwise indicated, all code in ModeShape
  * is licensed to you under the terms of the GNU Lesser General Public License as
  * published by the Free Software Foundation; either version 2.1 of
  * the License, or (at your option) any later version.
- * 
+ *
  * ModeShape is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
@@ -56,7 +56,7 @@ import org.overlord.sramp.query.xpath.ast.SubartifactSet;
  * defined by the S-RAMP specification and is a subset of the XPath 2.0 grammar.
  */
 public class XPathParser {
-	
+
 	private NamespaceContext namespaceContext;
 	private String defaultPrefix;
 
@@ -136,7 +136,7 @@ public class XPathParser {
 
 		if (tokens.hasNext())
 			throw new XPathParserException("Query string improperly terminated (found extra data)");
-		
+
 		return query;
 	}
 
@@ -160,12 +160,12 @@ public class XPathParser {
 	private LocationPath parseLocationPath(TokenStream tokens) {
 		String artifactModel = null;
 		String artifactType = null;
-		
+
 		if (!tokens.canConsume('/'))
 			throw new XPathParserException("Relative XPath queries not supported.");
 		if (!tokens.matches(XPathTokenizer.NAME) && !tokens.matches('/'))
 			throw new XPathParserException("Invalid artifact set (step 1).");
-		
+
 		// Is this of the form //{artifactType} ?
 		if (tokens.matches('/')) {
 			tokens.consume();
@@ -177,7 +177,7 @@ public class XPathParser {
 			String rootSrampSegment = tokens.consume();
 			if (!"s-ramp".equals(rootSrampSegment))
 				throw new XPathParserException("Query must begin with /s-ramp or //).");
-			
+
 			// Next is the artifact model
 			if (tokens.hasNext() && !tokens.matches('[')) {
 				if (!tokens.canConsume('/'))
@@ -185,7 +185,7 @@ public class XPathParser {
 				if (!tokens.matches(XPathTokenizer.NAME))
 					throw new XPathParserException("Invalid artifact set (step 2).");
 				artifactModel = tokens.consume();
-				
+
 				// And now the artifact type
 				if (tokens.hasNext() && !tokens.matches('[')) {
 					if (!tokens.canConsume('/'))
@@ -196,7 +196,7 @@ public class XPathParser {
 				}
 			}
 		}
-		
+
 		LocationPath locationPath = new LocationPath();
 		locationPath.setArtifactModel(artifactModel);
 		locationPath.setArtifactType(artifactType);
@@ -305,7 +305,7 @@ public class XPathParser {
 		ForwardPropertyStep forwardPropertyStep = new ForwardPropertyStep();
 		QName propertyQName = null;
 		SubartifactSet subartifactSet = null;
-		
+
 		if (tokens.canConsume('@')) {
 			propertyQName = parseQName(tokens, null);
 		} else {
@@ -316,7 +316,7 @@ public class XPathParser {
 				propertyQName = parseQName(tokens, null);
 			}
 		}
-		
+
 		forwardPropertyStep.setSubartifactSet(subartifactSet);
 		forwardPropertyStep.setPropertyQName(propertyQName);
 		return forwardPropertyStep;
@@ -333,7 +333,7 @@ public class XPathParser {
 		String prefix = null;
 		String localPart = null;
 		String namespace = null;
-		
+
 		if (!tokens.matches(XPathTokenizer.NAME))
 			throw new XPathParserException("Expected NAME type token.");
 		String ncname1 = tokens.consume();
@@ -395,14 +395,14 @@ public class XPathParser {
 	private SubartifactSet parseSubartifactSet(TokenStream tokens) {
 		if (!tokens.matches(XPathTokenizer.NAME) && !tokens.matches('.'))
 			throw new XPathParserException("Expression expected.");
-		
+
 		SubartifactSet subartifactSet = new SubartifactSet();
 		String relationshipOrFunction = tokens.consume();
-		
+
 		// If the next token is a [ then we have a relationship
 		// If the next token is a : or a ( then we have a (qualified or unqualified) function call
 		// If none of the above, then we have a relationship
-		
+
 		if (tokens.canConsume('[')) {
 			RelationshipPath relationshipPath = new RelationshipPath(relationshipOrFunction);
 			Predicate predicate = parsePredicate(tokens);
@@ -411,7 +411,7 @@ public class XPathParser {
 
 			subartifactSet.setRelationshipPath(relationshipPath);
 			subartifactSet.setPredicate(predicate);
-			
+
 			if (tokens.canConsume('/')) {
 				SubartifactSet sub_subartifactSet = parseSubartifactSet(tokens);
 				subartifactSet.setSubartifactSet(sub_subartifactSet);
@@ -491,7 +491,7 @@ public class XPathParser {
      * Remove any leading and trailing single-quotes or double-quotes from the supplied text.  Also
      * unescape any possibly escaped quote characters.  The result of calling this method will be
      * the real value of a quoted string from the query.
-     * 
+     *
      * @param text the input text
      * @return the text without leading and trailing quotes
      */
@@ -509,6 +509,6 @@ public class XPathParser {
 	 * @param artifactType the S-RAMP artifact type
 	 */
 	private String resolveArtifactModel(String artifactType) {
-		return ArtifactType.valueOf(artifactType).getModel();
+		return ArtifactType.valueOf(artifactType).getArtifactType().getModel();
 	}
 }

--- a/s-ramp-repository-jcr/src/main/java/org/overlord/sramp/repository/jcr/JCRNodeToArtifactFactory.java
+++ b/s-ramp-repository-jcr/src/main/java/org/overlord/sramp/repository/jcr/JCRNodeToArtifactFactory.java
@@ -19,6 +19,7 @@ import javax.jcr.Node;
 import javax.jcr.PathNotFoundException;
 
 import org.overlord.sramp.ArtifactType;
+import org.overlord.sramp.ArtifactTypeEnum;
 import org.overlord.sramp.repository.RepositoryException;
 import org.overlord.sramp.repository.jcr.mapper.XmlModel;
 import org.overlord.sramp.repository.jcr.mapper.XsdModel;
@@ -26,7 +27,7 @@ import org.s_ramp.xmlns._2010.s_ramp.BaseArtifactType;
 
 /**
  * A simple visitor that will create an S-RAMP artifact from a
- * 
+ *
  * @author eric.wittmann@redhat.com
  */
 public final class JCRNodeToArtifactFactory {
@@ -51,20 +52,21 @@ public final class JCRNodeToArtifactFactory {
 			throw new RuntimeException(e);
 		}
 	}
-	
+
 	/**
 	 * Creates a S-RAMP artifact from the given JCR node.
 	 * @param jcrNode a node in the JCR repo
 	 * @param artifactType the type of artifact represented by the {@link Node}
 	 * @return S-RAMP artifact
-	 * @throws RepositoryException 
+	 * @throws RepositoryException
 	 */
 	public static BaseArtifactType createArtifact(Node jcrNode, ArtifactType artifactType) throws RepositoryException {
-		if (artifactType == ArtifactType.XsdDocument) {
+		if (artifactType.getArtifactType() == ArtifactTypeEnum.XsdDocument) {
 		    return XsdModel.getXsdDocument(jcrNode);
-		} else if (artifactType == ArtifactType.XmlDocument) {
+		} else if (artifactType.getArtifactType() == ArtifactTypeEnum.XmlDocument) {
 		    return XmlModel.getXmlDocument(jcrNode);
 		} else {
+			// TODO implement this properly for all document types
 			return null;
 		}
 	}

--- a/s-ramp-repository-jcr/src/main/java/org/overlord/sramp/repository/jcr/JCRPersistence.java
+++ b/s-ramp-repository-jcr/src/main/java/org/overlord/sramp/repository/jcr/JCRPersistence.java
@@ -131,11 +131,11 @@ public class JCRPersistence implements PersistenceManager, DerivedArtifacts {
             sequencedNode.setProperty(JCRConstants.SRAMP_UUID, uuid);
             sequencedNode.setProperty(JCRConstants.SRAMP_NAME, filename);
             sequencedNode.setProperty(JCRConstants.OVERLORD_FILENAME, filename);
-            sequencedNode.setProperty(JCRConstants.SRAMP_ARTIFACT_MODEL, type.getModel());
-            sequencedNode.setProperty(JCRConstants.SRAMP_ARTIFACT_TYPE, type.getType());
+            sequencedNode.setProperty(JCRConstants.SRAMP_ARTIFACT_MODEL, type.getArtifactType().getModel());
+            sequencedNode.setProperty(JCRConstants.SRAMP_ARTIFACT_TYPE, type.getArtifactType().getType());
             session.save();
 
-            log.info("Created artifact of type " + type.getType() + " with UUID " + uuid);
+            log.info("Created artifact of type " + type.getArtifactType().getType() + " with UUID " + uuid);
 
             // Create an artifact from the sequenced node
             return JCRNodeToArtifactFactory.createArtifact(sequencedNode, type);

--- a/s-ramp-repository-jcr/src/main/java/org/overlord/sramp/repository/jcr/MapToJCRPath.java
+++ b/s-ramp-repository-jcr/src/main/java/org/overlord/sramp/repository/jcr/MapToJCRPath.java
@@ -29,7 +29,7 @@ public class MapToJCRPath {
      * @return path: "/artifact/<model>/<type>"
      */
     public static String getArtifactTypePath(ArtifactType type) {
-        return String.format(PATH, type.getModel(), type.getType());
+        return String.format(PATH, type.getArtifactType().getModel(), type.getArtifactType().getType());
     }
 
     /**

--- a/s-ramp-repository-jcr/src/main/java/org/overlord/sramp/repository/jcr/mapper/BaseArtifactModel.java
+++ b/s-ramp-repository-jcr/src/main/java/org/overlord/sramp/repository/jcr/mapper/BaseArtifactModel.java
@@ -45,7 +45,7 @@ public abstract class BaseArtifactModel {
 	protected static void mapBaseArtifactMetaData(Node jcrNode, BaseArtifactType artifact) throws RepositoryException {
 		try {
 			ArtifactType artifactType = ArtifactType.valueOf(artifact);
-			BaseArtifactEnum apiType = artifactType.getApiType();
+			BaseArtifactEnum apiType = artifactType.getArtifactType().getApiType();
 			artifact.setArtifactType(apiType);
 
 			// First map in the standard s-ramp meta-data

--- a/s-ramp-wagon/src/main/java/org/overlord/sramp/wagon/util/PomGenerator.java
+++ b/s-ramp-wagon/src/main/java/org/overlord/sramp/wagon/util/PomGenerator.java
@@ -50,13 +50,13 @@ public class PomGenerator {
 	public Document generatePom(BaseArtifactType artifact, ArtifactType type) throws Exception {
 		Document document = loadTemplate();
 
-		String groupId = type.getModel() + "." + type.getType();
+		String groupId = type.getArtifactType().getModel() + "." + type.getArtifactType().getType();
 		String artifactId = artifact.getUuid();
 		String version = artifact.getVersion();
 		String name = artifact.getName();
 		String description = artifact.getDescription();
 		// TODO this might not be good enough - might need to specify the artifact file extension in the ArtifactType enum
-		String pomType = type.getModel();
+		String pomType = type.getArtifactType().getModel();
 
 		if (version == null)
 			version = "1.0";


### PR DESCRIPTION
Refactored the ArtifactType to better support mime types.  The mime type
of the artifact should be passed into the persistence layer now.  The
binding layer (Atom) is responsible for setting the mime type of the
artifact being added or updated.
