### PR TITLE
(sramp-54) Seggregate junit tests so they don't interfere with each other

### DIFF
--- a/s-ramp-atom/pom.xml
+++ b/s-ramp-atom/pom.xml
@@ -98,6 +98,13 @@
 
 		<!-- Testing (note the scope) -->
 		<dependency>
+			<groupId>org.overlord.sramp</groupId>
+			<artifactId>s-ramp-repository-jcr</artifactId>
+			<version>${project.version}</version>
+			<classifier>tests</classifier>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<scope>test</scope>

--- a/s-ramp-atom/src/test/java/org/overlord/sramp/atom/services/ArtifactResourceTest.java
+++ b/s-ramp-atom/src/test/java/org/overlord/sramp/atom/services/ArtifactResourceTest.java
@@ -34,6 +34,7 @@ import org.s_ramp.xmlns._2010.s_ramp.Artifact;
 import org.s_ramp.xmlns._2010.s_ramp.XsdDocument;
 
 import test.org.overlord.sramp.atom.TestUtils;
+import test.org.overlord.sramp.repository.jcr.JCRRepositoryCleaner;
 
 /**
  * Test of the jax-rs resource that handles Artifacts.
@@ -48,6 +49,11 @@ public class ArtifactResourceTest extends BaseResourceTest {
 		getProviderFactory().registerProvider(SrampAtomExceptionMapper.class);
 		dispatcher.getRegistry().addPerRequestResource(ArtifactResource.class);
 	}
+
+    @Before
+    public void prepForTest() {
+        new JCRRepositoryCleaner().clean();
+    }
 
 	/**
 	 * @throws Exception

--- a/s-ramp-atom/src/test/java/org/overlord/sramp/atom/services/FeedResourceTest.java
+++ b/s-ramp-atom/src/test/java/org/overlord/sramp/atom/services/FeedResourceTest.java
@@ -36,6 +36,7 @@ import org.s_ramp.xmlns._2010.s_ramp.Property;
 import org.s_ramp.xmlns._2010.s_ramp.XsdDocument;
 
 import test.org.overlord.sramp.atom.TestUtils;
+import test.org.overlord.sramp.repository.jcr.JCRRepositoryCleaner;
 
 /**
  * Tests the s-ramp query features of the atom api binding.
@@ -50,6 +51,11 @@ public class FeedResourceTest extends BaseResourceTest {
 		dispatcher.getRegistry().addPerRequestResource(FeedResource.class);
 		dispatcher.getRegistry().addPerRequestResource(QueryResource.class);
 	}
+
+    @Before
+    public void prepForTest() {
+        new JCRRepositoryCleaner().clean();
+    }
 
 	/**
 	 * Tests the artifact feed.
@@ -72,15 +78,13 @@ public class FeedResourceTest extends BaseResourceTest {
 		ClientRequest request = new ClientRequest(generateURL("/s-ramp/xsd/XsdDocument"));
 		ClientResponse<Feed> response = request.get(Feed.class);
 		Feed feed = response.getEntity();
-		// TODO segregate the tests so that I can look for the 10 entries I just added
-//		int uuidsFound = 0;
-//		for (Entry entry : feed.getEntries()) {
-//			String entryUuid = entry.getId().toString();
-//			if (uuids.contains(entryUuid))
-//				uuidsFound++;
-//		}
-//		Assert.assertEquals(numEntries, uuidsFound);
-		Assert.assertTrue("Expected at least 10 entries.", feed.getEntries().size() >= 10);
+		int uuidsFound = 0;
+		for (Entry entry : feed.getEntries()) {
+			String entryUuid = entry.getId().toString();
+			if (uuids.contains(entryUuid))
+				uuidsFound++;
+		}
+		Assert.assertEquals(numEntries, uuidsFound);
 
 		// Make sure the query params work
 		request = new ClientRequest(generateURL("/s-ramp/xsd/XsdDocument?page=2&pageSize=2"));

--- a/s-ramp-atom/src/test/java/org/overlord/sramp/atom/services/QueryResourceTest.java
+++ b/s-ramp-atom/src/test/java/org/overlord/sramp/atom/services/QueryResourceTest.java
@@ -39,6 +39,7 @@ import org.s_ramp.xmlns._2010.s_ramp.Property;
 import org.s_ramp.xmlns._2010.s_ramp.XsdDocument;
 
 import test.org.overlord.sramp.atom.TestUtils;
+import test.org.overlord.sramp.repository.jcr.JCRRepositoryCleaner;
 
 /**
  * Tests the s-ramp query features of the atom api binding.
@@ -53,6 +54,11 @@ public class QueryResourceTest extends BaseResourceTest {
 		dispatcher.getRegistry().addPerRequestResource(FeedResource.class);
 		dispatcher.getRegistry().addPerRequestResource(QueryResource.class);
 	}
+
+    @Before
+    public void prepForTest() {
+        new JCRRepositoryCleaner().clean();
+    }
 
 	/**
 	 * @throws Exception
@@ -74,15 +80,13 @@ public class QueryResourceTest extends BaseResourceTest {
 		ClientRequest request = new ClientRequest(generateURL("/s-ramp?query=xsd/XsdDocument"));
 		ClientResponse<Feed> response = request.get(Feed.class);
 		Feed feed = response.getEntity();
-		// TODO segregate the tests so that I can look for the 10 entries I just added
-//		int uuidsFound = 0;
-//		for (Entry entry : feed.getEntries()) {
-//			String entryUuid = entry.getId().toString();
-//			if (uuids.contains(entryUuid))
-//				uuidsFound++;
-//		}
-//		Assert.assertEquals(numEntries, uuidsFound);
-		Assert.assertTrue("Expected at least 10 entries.", feed.getEntries().size() >= 10);
+		int uuidsFound = 0;
+		for (Entry entry : feed.getEntries()) {
+			String entryUuid = entry.getId().toString();
+			if (uuids.contains(entryUuid))
+				uuidsFound++;
+		}
+		Assert.assertEquals(numEntries, uuidsFound);
 
 		// Do it again with POST (multipart form data)
 		request = new ClientRequest(generateURL("/s-ramp"));
@@ -91,15 +95,13 @@ public class QueryResourceTest extends BaseResourceTest {
 		request.body(MediaType.MULTIPART_FORM_DATA_TYPE, formData);
 		response = request.post(Feed.class);
 		feed = response.getEntity();
-		// TODO segregate the tests so that I can look for the 10 entries I just added
-//		uuidsFound = 0;
-//		for (Entry entry : feed.getEntries()) {
-//			String entryUuid = entry.getId().toString();
-//			if (uuids.contains(entryUuid))
-//				uuidsFound++;
-//		}
-//		Assert.assertEquals(numEntries, uuidsFound);
-		Assert.assertTrue("Expected at least 10 entries.", feed.getEntries().size() >= 10);
+		uuidsFound = 0;
+		for (Entry entry : feed.getEntries()) {
+			String entryUuid = entry.getId().toString();
+			if (uuids.contains(entryUuid))
+				uuidsFound++;
+		}
+		Assert.assertEquals(numEntries, uuidsFound);
 
 		// Do a query using GET with multiple documents and using the query params
 		String stampVal = UUID.randomUUID().toString();

--- a/s-ramp-repository-jcr/src/test/java/org/overlord/sramp/repository/jcr/JCRPersistenceTest.java
+++ b/s-ramp-repository-jcr/src/test/java/org/overlord/sramp/repository/jcr/JCRPersistenceTest.java
@@ -22,6 +22,7 @@ import java.util.Set;
 
 import junit.framework.Assert;
 
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.overlord.sramp.ArtifactType;
@@ -35,37 +36,44 @@ import org.s_ramp.xmlns._2010.s_ramp.XsdDocument;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import test.org.overlord.sramp.repository.jcr.JCRRepositoryCleaner;
+
 /**
  * @author <a href="mailto:kurt.stam@gmail.com">Kurt Stam</a>
  */
 public class JCRPersistenceTest {
-    
+
     private Logger log = LoggerFactory.getLogger(this.getClass());
 
     private static PersistenceManager persistenceManager = null;
-    
+
     @BeforeClass
     public static void setup() {
         persistenceManager = PersistenceFactory.newInstance();
     }
-    
+
+    @Before
+    public void prepForTest() {
+        new JCRRepositoryCleaner().clean();
+    }
+
     @Test
     public void testSavePO_XSD() throws Exception {
         String artifactFileName = "PO.xsd";
         InputStream POXsd = this.getClass().getResourceAsStream("/sample-files/xsd/" + artifactFileName);
-        
+
         BaseArtifactType artifact = persistenceManager.persistArtifact(artifactFileName, ArtifactType.XsdDocument, POXsd);
-        
+
         Assert.assertNotNull(artifact);
         log.info("persisted PO.xsd to JCR, returned artifact uuid=" + artifact.getUuid());
-        
+
         //print out the derived node
         //persistenceManager.printArtifactGraph(artifact.getUuid(), ArtifactType.XsdDocument);
-        
+
         Assert.assertEquals(XsdDocument.class, artifact.getClass());
         Assert.assertEquals(new Long(2376l), ((XsdDocument) artifact).getContentSize());
     }
-    
+
     /**
 	 * For now expecting a runtime exception since the ModeShape Sequencer for
 	 * XML is not yet up sequencing all the necessary artifacts.
@@ -75,9 +83,9 @@ public class JCRPersistenceTest {
     public void testSavePO_XML() throws Exception {
         String artifactFileName = "PO.xml";
         InputStream POXml = this.getClass().getResourceAsStream("/sample-files/xml/" + artifactFileName);
-        
+
         BaseArtifactType artifact = persistenceManager.persistArtifact(artifactFileName, ArtifactType.XmlDocument, POXml);
-        
+
         Assert.assertNotNull(artifact);
         log.info("persisted PO.xml to JCR, returned artifact uuid=" + artifact.getUuid());
 
@@ -92,15 +100,15 @@ public class JCRPersistenceTest {
     public void testGetArtifact_XSD() throws Exception {
         String artifactFileName = "PO.xsd";
         InputStream POXsd = this.getClass().getResourceAsStream("/sample-files/xsd/" + artifactFileName);
-        
+
         BaseArtifactType artifact = persistenceManager.persistArtifact(artifactFileName, ArtifactType.XsdDocument, POXsd);
-        
+
         Assert.assertNotNull(artifact);
         log.info("persisted PO.xsd to JCR, returned artifact uuid=" + artifact.getUuid());
-        
+
         Assert.assertEquals(XsdDocument.class, artifact.getClass());
         Assert.assertEquals(new Long(2376l), ((XsdDocument) artifact).getContentSize());
-        
+
         BaseArtifactType artifact2 = persistenceManager.getArtifact(artifact.getUuid(), ArtifactType.XsdDocument);
         Assert.assertEquals(artifact.getUuid(), artifact2.getUuid());
         Assert.assertEquals(artifact.getCreatedBy(), artifact2.getCreatedBy());
@@ -110,7 +118,7 @@ public class JCRPersistenceTest {
         Assert.assertEquals(artifact.getVersion(), artifact2.getVersion());
         Assert.assertEquals(artifact.getLastModifiedTimestamp(), artifact2.getLastModifiedTimestamp());
     }
-    
+
     /**
      * Tests the getArtifacts method on the persistence manager.
      * @throws Exception
@@ -130,7 +138,7 @@ public class JCRPersistenceTest {
         Assert.assertNotNull(artifact);
         String uuid2 = artifact.getUuid();
 		log.info("persisted PO.xsd (again) to JCR, returned artifact uuid=" + uuid2);
-		
+
 		List<BaseArtifactType> artifacts = persistenceManager.getArtifacts(ArtifactType.XsdDocument);
 		Assert.assertNotNull(artifacts);
 		Assert.assertTrue("Wrong number of artifacts returned (should have at least 2).", artifacts.size() >= 2);
@@ -161,14 +169,14 @@ public class JCRPersistenceTest {
         Assert.assertEquals(XsdDocument.class, artifact.getClass());
         Assert.assertEquals(new Long(2376l), ((XsdDocument) artifact).getContentSize());
         Assert.assertEquals(artifactFileName, artifact.getName());
-        
+
         // Now update the artifact
         artifact = persistenceManager.getArtifact(artifact.getUuid(), ArtifactType.XsdDocument);
         artifact.setName("My PO");
         artifact.setDescription("A new description of the PO.xsd artifact.");
         artifact.setVersion("2.0.13");
         persistenceManager.updateArtifact(artifact, ArtifactType.XsdDocument);
-        
+
         // Now verify the meta-data was updated
         artifact = persistenceManager.getArtifact(artifact.getUuid(), ArtifactType.XsdDocument);
         Assert.assertEquals("My PO", artifact.getName());
@@ -190,7 +198,7 @@ public class JCRPersistenceTest {
         log.info("persisted PO.xsd to JCR, returned artifact uuid=" + artifact.getUuid());
         Assert.assertEquals(XsdDocument.class, artifact.getClass());
         Assert.assertEquals(new Long(2376l), ((XsdDocument) artifact).getContentSize());
-        
+
         // Now update the artifact
         artifact = persistenceManager.getArtifact(artifact.getUuid(), ArtifactType.XsdDocument);
         Assert.assertTrue("Expected 0 properties.", artifact.getProperty().isEmpty());

--- a/s-ramp-repository-jcr/src/test/java/test/org/overlord/sramp/repository/jcr/JCRRepositoryCleaner.java
+++ b/s-ramp-repository-jcr/src/test/java/test/org/overlord/sramp/repository/jcr/JCRRepositoryCleaner.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2012 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package test.org.overlord.sramp.repository.jcr;
+
+import javax.jcr.Node;
+import javax.jcr.PathNotFoundException;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+
+import org.overlord.sramp.repository.jcr.JCRRepository;
+
+/**
+ * Cleans the JCR repository to get it ready for a unit test.  This class
+ * is used for each unit test so that they don't interfere with each other.
+ *
+ * @author eric.wittmann@redhat.com
+ */
+public class JCRRepositoryCleaner {
+
+	/**
+	 * Constructor.
+	 */
+	public JCRRepositoryCleaner() {
+	}
+
+	/**
+	 * Called to clean the repository.
+	 * @throws Exception
+	 */
+	public void clean() {
+		Session session = null;
+		try {
+            session = JCRRepository.getSession();
+            Node artifactContentRoot = getNode(session, "/artifact");
+            if (artifactContentRoot != null) {
+	        	artifactContentRoot.remove();
+	        	System.out.println("Removed /artifact tree (cleaned)");
+            }
+
+            Node srampRoot = getNode(session, "/s-ramp");
+            if (srampRoot != null) {
+	        	srampRoot.remove();
+	        	System.out.println("Removed /s-ramp tree (cleaned)");
+            }
+
+        	session.save();
+		} catch (PathNotFoundException e) {
+			// The node doesn't exist - so no worries.
+		} catch (Throwable t) {
+			throw new RuntimeException(t);
+		} finally {
+			session.logout();
+		}
+	}
+
+	/**
+	 * Gets a JCR node by path.  Returns null if the path doesn't exist.
+	 * @param session
+	 * @param path
+	 * @throws RepositoryException
+	 */
+	private Node getNode(Session session, String path) throws RepositoryException {
+		try {
+			return session.getNode(path);
+		} catch (PathNotFoundException e) {
+			return null;
+		} catch (RepositoryException e) {
+			throw e;
+		}
+	}
+
+}


### PR DESCRIPTION
Added a class that can clean the JCR repository in between junit tests. This allows the tests to essentially be sandboxed, even though (in
truth) what's really happening is that the artifact and s-ramp JCR nodes
are just being whacked.
