### PR TITLE
(sramp-99) Derived artifact meta-data bug fix

### DIFF
--- a/s-ramp-atom/src/test/java/org/overlord/sramp/atom/services/ArtifactResourceTest.java
+++ b/s-ramp-atom/src/test/java/org/overlord/sramp/atom/services/ArtifactResourceTest.java
@@ -44,6 +44,7 @@ import org.overlord.sramp.atom.providers.SrampAtomExceptionProvider;
 import org.s_ramp.xmlns._2010.s_ramp.Artifact;
 import org.s_ramp.xmlns._2010.s_ramp.BaseArtifactType;
 import org.s_ramp.xmlns._2010.s_ramp.Document;
+import org.s_ramp.xmlns._2010.s_ramp.Message;
 import org.s_ramp.xmlns._2010.s_ramp.UserDefinedArtifactType;
 import org.s_ramp.xmlns._2010.s_ramp.WsdlDocument;
 import org.s_ramp.xmlns._2010.s_ramp.XsdDocument;
@@ -331,7 +332,6 @@ public class ArtifactResourceTest extends AbstractResourceTest {
 		// Make sure we can query it now
 		ClientRequest request = new ClientRequest(generateURL("/s-ramp/wsdl/WsdlDocument/" + uuid));
 		ClientResponse<Entry> response = request.get(Entry.class);
-
 		Entry entry = response.getEntity();
 		BaseArtifactType arty = SrampAtomUtils.unwrapSrampArtifact(entry);
 		Assert.assertNotNull(arty);
@@ -354,7 +354,16 @@ public class ArtifactResourceTest extends AbstractResourceTest {
 		}
 		Assert.assertNotNull(findReqMsgUuid);
 
-		// TODO retrieve full meta-data for the wsdl Message so we can do some interesting assertions
+		// Get the full meta data for the derived Message
+		request = new ClientRequest(generateURL("/s-ramp/wsdl/Message/" + findReqMsgUuid));
+		response = request.get(Entry.class);
+		entry = response.getEntity();
+		arty = SrampAtomUtils.unwrapSrampArtifact(entry);
+		Assert.assertNotNull(arty);
+		Assert.assertTrue(arty instanceof Message);
+		Message message = (Message) arty;
+		Assert.assertEquals("findRequest", message.getNCName());
+		Assert.assertEquals("http://ewittman.redhat.com/sample/2012/09/wsdl/sample.wsdl", message.getNamespace());
 	}
 
 	/**

--- a/s-ramp-core/src/main/java/org/overlord/sramp/visitors/HierarchicalArtifactVisitorAdapter.java
+++ b/s-ramp-core/src/main/java/org/overlord/sramp/visitors/HierarchicalArtifactVisitorAdapter.java
@@ -39,6 +39,7 @@ import org.s_ramp.xmlns._2010.s_ramp.Event;
 import org.s_ramp.xmlns._2010.s_ramp.Fault;
 import org.s_ramp.xmlns._2010.s_ramp.InformationType;
 import org.s_ramp.xmlns._2010.s_ramp.Message;
+import org.s_ramp.xmlns._2010.s_ramp.NamedWsdlDerivedArtifactType;
 import org.s_ramp.xmlns._2010.s_ramp.Operation;
 import org.s_ramp.xmlns._2010.s_ramp.OperationInput;
 import org.s_ramp.xmlns._2010.s_ramp.OperationOutput;
@@ -117,6 +118,14 @@ public abstract class HierarchicalArtifactVisitorAdapter implements ArtifactVisi
 	}
 
 	/**
+	 * Common visit method for named WSDL derived artifacts.
+	 * @param artifact
+	 */
+	protected void visitNamedWsdlDerived(NamedWsdlDerivedArtifactType artifact) {
+		// Subclasses can do common visit logic here
+	}
+
+	/**
 	 * Common visit method for XSD derived artifacts.
 	 * @param artifact
 	 */
@@ -155,7 +164,7 @@ public abstract class HierarchicalArtifactVisitorAdapter implements ArtifactVisi
 	protected void visitSoa(SoaModelType artifact) {
 		// Subclasses can do common visit logic here
 	}
-	
+
 	/**
      * Common visit method for UserDefined artifacts.
      * @param artifact
@@ -163,7 +172,7 @@ public abstract class HierarchicalArtifactVisitorAdapter implements ArtifactVisi
     protected void visitUserDefined(UserDefinedArtifactType artifact) {
         // Subclasses can do common visit logic here
     }
-	
+
 	/**
 	 * @see org.overlord.sramp.visitors.ArtifactVisitor#visit(org.s_ramp.xmlns._2010.s_ramp.Document)
 	 */
@@ -295,6 +304,7 @@ public abstract class HierarchicalArtifactVisitorAdapter implements ArtifactVisi
 		visitBase(artifact);
 		visitDerived(artifact);
 		visitWsdlDerived(artifact);
+		visitNamedWsdlDerived(artifact);
 	}
 
 	/**
@@ -305,6 +315,7 @@ public abstract class HierarchicalArtifactVisitorAdapter implements ArtifactVisi
 		visitBase(artifact);
 		visitDerived(artifact);
 		visitWsdlDerived(artifact);
+		visitNamedWsdlDerived(artifact);
 	}
 
 	/**
@@ -324,6 +335,7 @@ public abstract class HierarchicalArtifactVisitorAdapter implements ArtifactVisi
 		visitBase(artifact);
 		visitDerived(artifact);
 		visitWsdlDerived(artifact);
+		visitNamedWsdlDerived(artifact);
 	}
 
 	/**
@@ -334,6 +346,7 @@ public abstract class HierarchicalArtifactVisitorAdapter implements ArtifactVisi
 		visitBase(artifact);
 		visitDerived(artifact);
 		visitWsdlDerived(artifact);
+		visitNamedWsdlDerived(artifact);
 	}
 
 	/**
@@ -344,6 +357,7 @@ public abstract class HierarchicalArtifactVisitorAdapter implements ArtifactVisi
 		visitBase(artifact);
 		visitDerived(artifact);
 		visitWsdlDerived(artifact);
+		visitNamedWsdlDerived(artifact);
 	}
 
 	/**
@@ -354,6 +368,7 @@ public abstract class HierarchicalArtifactVisitorAdapter implements ArtifactVisi
 		visitBase(artifact);
 		visitDerived(artifact);
 		visitWsdlDerived(artifact);
+		visitNamedWsdlDerived(artifact);
 	}
 
 	/**
@@ -364,6 +379,7 @@ public abstract class HierarchicalArtifactVisitorAdapter implements ArtifactVisi
 		visitBase(artifact);
 		visitDerived(artifact);
 		visitWsdlDerived(artifact);
+		visitNamedWsdlDerived(artifact);
 	}
 
 	/**
@@ -374,6 +390,7 @@ public abstract class HierarchicalArtifactVisitorAdapter implements ArtifactVisi
 		visitBase(artifact);
 		visitDerived(artifact);
 		visitWsdlDerived(artifact);
+		visitNamedWsdlDerived(artifact);
 	}
 
 	/**
@@ -384,6 +401,7 @@ public abstract class HierarchicalArtifactVisitorAdapter implements ArtifactVisi
 		visitBase(artifact);
 		visitDerived(artifact);
 		visitWsdlDerived(artifact);
+		visitNamedWsdlDerived(artifact);
 	}
 
 	/**
@@ -394,6 +412,7 @@ public abstract class HierarchicalArtifactVisitorAdapter implements ArtifactVisi
 		visitBase(artifact);
 		visitDerived(artifact);
 		visitWsdlDerived(artifact);
+		visitNamedWsdlDerived(artifact);
 	}
 
 	/**
@@ -404,6 +423,7 @@ public abstract class HierarchicalArtifactVisitorAdapter implements ArtifactVisi
 		visitBase(artifact);
 		visitDerived(artifact);
 		visitWsdlDerived(artifact);
+		visitNamedWsdlDerived(artifact);
 	}
 
 	/**
@@ -414,6 +434,7 @@ public abstract class HierarchicalArtifactVisitorAdapter implements ArtifactVisi
 		visitBase(artifact);
 		visitDerived(artifact);
 		visitWsdlDerived(artifact);
+		visitNamedWsdlDerived(artifact);
 	}
 
 	/**
@@ -424,6 +445,7 @@ public abstract class HierarchicalArtifactVisitorAdapter implements ArtifactVisi
 		visitBase(artifact);
 		visitDerived(artifact);
 		visitWsdlDerived(artifact);
+		visitNamedWsdlDerived(artifact);
 	}
 
 	/**
@@ -434,6 +456,7 @@ public abstract class HierarchicalArtifactVisitorAdapter implements ArtifactVisi
 		visitBase(artifact);
 		visitDerived(artifact);
 		visitWsdlDerived(artifact);
+		visitNamedWsdlDerived(artifact);
 	}
 
 	/**

--- a/s-ramp-repository-jcr/src/main/java/org/overlord/sramp/repository/jcr/ArtifactToJCRNodeVisitor.java
+++ b/s-ramp-repository-jcr/src/main/java/org/overlord/sramp/repository/jcr/ArtifactToJCRNodeVisitor.java
@@ -31,8 +31,11 @@ import javax.jcr.Value;
 
 import org.overlord.sramp.visitors.HierarchicalArtifactVisitorAdapter;
 import org.s_ramp.xmlns._2010.s_ramp.BaseArtifactType;
+import org.s_ramp.xmlns._2010.s_ramp.DerivedArtifactType;
+import org.s_ramp.xmlns._2010.s_ramp.NamedWsdlDerivedArtifactType;
 import org.s_ramp.xmlns._2010.s_ramp.Relationship;
 import org.s_ramp.xmlns._2010.s_ramp.Target;
+import org.s_ramp.xmlns._2010.s_ramp.WsdlDerivedArtifactType;
 
 /**
  * An artifact visitor used to update a JCR node.  This class is responsible
@@ -66,6 +69,37 @@ public class ArtifactToJCRNodeVisitor extends HierarchicalArtifactVisitorAdapter
 			updateArtifactMetaData(artifact);
 			updateArtifactProperties(artifact);
 			updateGenericRelationships(artifact);
+		} catch (Exception e) {
+			error = e;
+		}
+	}
+
+	/**
+	 * @see org.overlord.sramp.visitors.HierarchicalArtifactVisitorAdapter#visitDerived(org.s_ramp.xmlns._2010.s_ramp.DerivedArtifactType)
+	 */
+	@Override
+	protected void visitDerived(DerivedArtifactType artifact) {
+	}
+
+	/**
+	 * @see org.overlord.sramp.visitors.HierarchicalArtifactVisitorAdapter#visitWsdlDerived(org.s_ramp.xmlns._2010.s_ramp.WsdlDerivedArtifactType)
+	 */
+	@Override
+	protected void visitWsdlDerived(WsdlDerivedArtifactType artifact) {
+		try {
+			this.jcrNode.setProperty("sramp:namespace", artifact.getNamespace());
+		} catch (Exception e) {
+			error = e;
+		}
+	}
+
+	/**
+	 * @see org.overlord.sramp.visitors.HierarchicalArtifactVisitorAdapter#visitNamedWsdlDerived(org.s_ramp.xmlns._2010.s_ramp.NamedWsdlDerivedArtifactType)
+	 */
+	@Override
+	protected void visitNamedWsdlDerived(NamedWsdlDerivedArtifactType artifact) {
+		try {
+			this.jcrNode.setProperty("sramp:ncName", artifact.getNCName());
 		} catch (Exception e) {
 			error = e;
 		}

--- a/s-ramp-repository-jcr/src/main/java/org/overlord/sramp/repository/jcr/mapper/JCRNodeToArtifactVisitor.java
+++ b/s-ramp-repository-jcr/src/main/java/org/overlord/sramp/repository/jcr/mapper/JCRNodeToArtifactVisitor.java
@@ -35,6 +35,7 @@ import org.s_ramp.xmlns._2010.s_ramp.BaseArtifactEnum;
 import org.s_ramp.xmlns._2010.s_ramp.BaseArtifactType;
 import org.s_ramp.xmlns._2010.s_ramp.DerivedArtifactType;
 import org.s_ramp.xmlns._2010.s_ramp.DocumentArtifactType;
+import org.s_ramp.xmlns._2010.s_ramp.NamedWsdlDerivedArtifactType;
 import org.s_ramp.xmlns._2010.s_ramp.Relationship;
 import org.s_ramp.xmlns._2010.s_ramp.Target;
 import org.s_ramp.xmlns._2010.s_ramp.UserDefinedArtifactType;
@@ -149,6 +150,15 @@ public class JCRNodeToArtifactVisitor extends HierarchicalArtifactVisitorAdapter
 	 */
 	@Override
 	protected void visitWsdlDerived(WsdlDerivedArtifactType artifact) {
+		artifact.setNamespace(getProperty(jcrNode, "sramp:namespace"));
+	}
+
+	/**
+	 * @see org.overlord.sramp.visitors.HierarchicalArtifactVisitorAdapter#visitNamedWsdlDerived(org.s_ramp.xmlns._2010.s_ramp.NamedWsdlDerivedArtifactType)
+	 */
+	@Override
+	protected void visitNamedWsdlDerived(NamedWsdlDerivedArtifactType artifact) {
+		artifact.setNCName(getProperty(jcrNode, "sramp:ncName"));
 	}
 
 	/**


### PR DESCRIPTION
Fixed a problem (SRAMP-99) where derived artifact meta-data could not be
retrieved.  This was fixed by querying for the JCR node by UUID for
derived artifacts (rather than simply navigating directly to a JCR node
by path).
