### PR TITLE
S-RAMP 71, fixing dependency issue for the client

### DIFF
--- a/s-ramp-client/pom.xml
+++ b/s-ramp-client/pom.xml
@@ -12,6 +12,7 @@
  <name>S-RAMP Client</name>
  <description>A general purpose client to communicate with any S-RAMP spec-compliant repository.</description>
  <build>
+ <!-- 
   <pluginManagement>
    <plugins>
     <plugin>
@@ -38,6 +39,23 @@
      </execution>
     </executions>
    </plugin>
+    -->
+  <plugins>
+   <plugin>
+    <artifactId>maven-dependency-plugin</artifactId>
+    <executions>
+     <execution>
+      <phase>install</phase>
+      <goals>
+       <goal>copy-dependencies</goal>
+      </goals>
+      <configuration>
+       <outputDirectory>${project.build.directory}/lib</outputDirectory>
+      </configuration>
+     </execution>
+    </executions>
+   </plugin>
+
   </plugins>
  </build>
  <dependencies>

--- a/s-ramp-client/sramp.sh
+++ b/s-ramp-client/sramp.sh
@@ -20,7 +20,7 @@ fi
 if [ "$1" == "brms" ]
 then
    echo "Uploading brms package '$2' to S-RAMP..."
-   java -cp target/s-ramp-clientwithdependencies.jar org.overlord.sramp.client.brms.BrmsPkgToSramp $2 $3 $4
+   java -cp target/s-ramp-client-0.0.3-SNAPSHOT.jar:$(echo target/lib/*.jar | tr ' ' ':') org.overlord.sramp.client.brms.BrmsPkgToSramp $2 $3 $4
 fi
 
 exit 0


### PR DESCRIPTION
target/lib which contains all jars the s-ramp client depends on.
Hopefully we get to prune this soon.
