### PR TITLE
(sramp-103) Better persistence for multi-part creates

### DIFF
--- a/s-ramp-atom/src/test/java/org/overlord/sramp/atom/services/ArtifactResourceTest.java
+++ b/s-ramp-atom/src/test/java/org/overlord/sramp/atom/services/ArtifactResourceTest.java
@@ -27,9 +27,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.ws.rs.Consumes;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
 import javax.xml.namespace.QName;
 
 import org.apache.commons.io.IOUtils;
@@ -385,23 +382,17 @@ public class ArtifactResourceTest extends AbstractResourceTest {
 		Assert.assertEquals(PartEnum.PART, parts.get(0).getArtifactType());
 		Assert.assertNotNull(parts.get(0).getValue());
 	}
-	
-    @Path("s-ramp")
-    public static interface MultipartClient
-    {
-       @Path("xsd/XsdDocument")
-       @POST
-       @Consumes(MultipartConstants.MULTIPART_RELATED)
-       public void postRelated(MultipartRelatedOutput output);
-    }
-	
+
+	/**
+	 * Tests the multi-part create scenario.
+	 */
 	@Test
 	public void testMultiPartCreate() {
 	    try {
 	        ClientRequest request = new ClientRequest(generateURL("/s-ramp/core/XmlDocument"));
 
 	        MultipartRelatedOutput output = new MultipartRelatedOutput();
-	        
+
 	        XmlDocument xmlDocument = new XmlDocument();
 	        xmlDocument.setArtifactType(BaseArtifactEnum.XML_DOCUMENT);
 	        xmlDocument.setCreatedBy("kurt");
@@ -409,7 +400,7 @@ public class ArtifactResourceTest extends AbstractResourceTest {
 	        xmlDocument.setName("PO.xml");
 	        xmlDocument.setUuid("my-uuid");
 	        xmlDocument.setVersion("1.0");
-	        
+
 	        Entry atomEntry = new Entry();
 	        Artifact arty = new Artifact();
 	        arty.setXmlDocument(xmlDocument);
@@ -417,16 +408,16 @@ public class ArtifactResourceTest extends AbstractResourceTest {
 
 	        MediaType mediaType = new MediaType("application", "atom+xml");
 	        output.addPart(atomEntry, mediaType);
-	        
+
 	        String artifactFileName = "PO.xml";
 	        InputStream contentStream = this.getClass().getResourceAsStream("/sample-files/core/" + artifactFileName);
 	        MediaType mediaType2 = new MediaType("application", "xml");
 	        output.addPart(contentStream, mediaType2);
-	        
+
 	        request.body(MultipartConstants.MULTIPART_RELATED, output);
-    
+
             ClientResponse<Entry> response = request.post(Entry.class);
-//    
+//
             Entry entry = response.getEntity();
             Assert.assertEquals(artifactFileName, entry.getTitle());
             Artifact artifact = entry.getAnyOtherJAXBObject(Artifact.class);

--- a/s-ramp-client/sramp.sh
+++ b/s-ramp-client/sramp.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
+
+# Enter the interactive shell
+if [ "$1" == "-i" ]
+then
+    java -cp target/s-ramp-client-0.0.3-SNAPSHOT.jar:$(echo target/lib/*.jar | tr ' ' ':') org.overlord.sramp.client.shell.SrampShell
+    exit 0
+fi
+
 echo "******************************************************************************************************"
 echo "*                     _________         __________    _____      _____ __________                    *"
 echo "*                    /   _____/         \______   \  /  _  \    /     \\\______   \                   *"
@@ -9,9 +17,10 @@ echo "*                           \/                  \/         \/         \/  
 echo "* JBoss S-RAMP Kurt Stam and Eric Wittmann, Licensed under the Apache License, V2.0, Copyrights 2012 *"
 echo "******************************************************************************************************"
 
-if [ $# -lt 2 ]
-  then
+if [ $# -lt 1 ]
+then
     echo "Not enough arguments were supplied. Usage:"
+    echo "sramp.sh -i  ....runs the S-RAMP interactive shell"
     echo "sramp.sh brms [pkg_in_brms] [tag] [baseUrl] .....obtains 'pkg_in_brms' from brms/drools and uploads 
                                                            to s-ramp"
     exit 0
@@ -19,8 +28,7 @@ fi
 
 if [ "$1" == "brms" ]
 then
-   echo "Uploading brms package '$2' to S-RAMP..."
-   java -cp target/s-ramp-client-0.0.3-SNAPSHOT.jar:$(echo target/lib/*.jar | tr ' ' ':') org.overlord.sramp.client.brms.BrmsPkgToSramp $2 $3 $4
+    echo "Uploading brms package '$2' to S-RAMP..."
+    java -cp target/s-ramp-client-0.0.3-SNAPSHOT.jar:$(echo target/lib/*.jar | tr ' ' ':') org.overlord.sramp.client.brms.BrmsPkgToSramp $2 $3 $4
+    exit 0
 fi
-
-exit 0


### PR DESCRIPTION
Re-use the Artifact->JCRNode visitor in the create call so that
createMultiPart doesn't need to do a persist followed by an update.
