### PR TITLE
(SRAMP-98) Configurable data directory location (for ModeShape data)

### DIFF
--- a/s-ramp-atom/src/main/java/org/overlord/sramp/atom/SrampLifeCycle.java
+++ b/s-ramp-atom/src/main/java/org/overlord/sramp/atom/SrampLifeCycle.java
@@ -9,15 +9,17 @@ import org.overlord.sramp.repository.PersistenceFactory;
  * Listener for deploy/undeploy events.
  */
 public class SrampLifeCycle implements ServletContextListener {
-	private static final long serialVersionUID = 1L;
-       	
-	
 
-    @Override
+	/**
+	 * @see javax.servlet.ServletContextListener#contextInitialized(javax.servlet.ServletContextEvent)
+	 */
+	@Override
     public void contextInitialized(ServletContextEvent sce) {
-
     }
 
+    /**
+     * @see javax.servlet.ServletContextListener#contextDestroyed(javax.servlet.ServletContextEvent)
+     */
     @Override
     public void contextDestroyed(ServletContextEvent sce) {
         PersistenceFactory.newInstance().shutdown();

--- a/s-ramp-repository-jcr/src/main/java/org/overlord/sramp/repository/jcr/JCRNodeToArtifactFactory.java
+++ b/s-ramp-repository-jcr/src/main/java/org/overlord/sramp/repository/jcr/JCRNodeToArtifactFactory.java
@@ -79,7 +79,7 @@ public final class JCRNodeToArtifactFactory {
 						Node node = session.getNodeByIdentifier(ident);
 						return node.getProperty("sramp:uuid").getString();
 					} catch (Exception e) {
-						log.error("Error resolving JCR reference.", e);
+						log.debug("Error resolving JCR reference.", e);
 					}
 					return null;
 				}

--- a/s-ramp-repository-jcr/src/main/java/org/overlord/sramp/repository/jcr/JCRPersistence.java
+++ b/s-ramp-repository-jcr/src/main/java/org/overlord/sramp/repository/jcr/JCRPersistence.java
@@ -454,7 +454,7 @@ public class JCRPersistence implements PersistenceManager, DerivedArtifacts {
 	 */
 	@Override
 	public void shutdown() {
-	    JCRRepository.shutdown();
+		JCRRepository.destroy();
 	}
 
 	/**

--- a/s-ramp-repository-jcr/src/main/java/org/overlord/sramp/repository/jcr/JCRRepository.java
+++ b/s-ramp-repository-jcr/src/main/java/org/overlord/sramp/repository/jcr/JCRRepository.java
@@ -15,6 +15,7 @@
  */
 package org.overlord.sramp.repository.jcr;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
@@ -35,6 +36,7 @@ import javax.jcr.Session;
 
 import org.apache.commons.configuration.CompositeConfiguration;
 import org.apache.commons.configuration.SystemConfiguration;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.modeshape.common.collection.Problems;
 import org.modeshape.jcr.RepositoryConfiguration;
@@ -46,49 +48,81 @@ import org.slf4j.LoggerFactory;
 public class JCRRepository {
 
     private static Logger log = LoggerFactory.getLogger(JCRRepository.class);
-
-    //private static String USER           = "s-ramp";
-    //private static char[] PWD            = "s-ramp".toCharArray();
     private static String WORKSPACE_NAME = "default";
 
-    private static Repository repository = null;
-    private static RepositoryFactory theFactory = null;
+    private static JCRRepository instance;
+    public static synchronized JCRRepository getInstance() throws RepositoryException {
+    	if (instance == null) {
+    		instance = new JCRRepository();
+    		instance.startup();
+    	}
+    	return instance;
+    }
+    public static synchronized void destroy() {
+		try {
+			getInstance().shutdown();
+		} catch (RepositoryException e) {
+			log.error("Failed to shut down ModeShape.", e);
+		}
+    	instance = null;
+    }
+
+    private Repository repository = null;
+    private RepositoryFactory theFactory = null;
+    private File tempConfigDir;
 
     /**
-     * Gets the singleton instance of the JCR Repository.
+	 * Constructor.
+	 */
+	public JCRRepository() {
+	}
+
+	/**
+	 * Gets the underlying JCR repository.
+	 */
+	public Repository get() {
+		return repository;
+	}
+
+    /**
+     * Starts up the JCR repository.
      * @throws RepositoryException
      */
-    private static synchronized Repository getInstance() throws RepositoryException {
+    private void startup() throws RepositoryException {
         try {
-            if (repository==null) {
-                Map<String,String> parameters = new HashMap<String,String>();
-                URL configUrl = getConfigurationUrl();
-                RepositoryConfiguration config = RepositoryConfiguration.read(configUrl);
-                Problems problems = config.validate();
-                if (problems.hasErrors()) {
-                    throw new RepositoryException(problems.toString());
-                }
-                parameters.put("org.modeshape.jcr.URL",configUrl.toExternalForm());
-                for (RepositoryFactory factory : ServiceLoader.load(RepositoryFactory.class)) {
-                    theFactory = factory;
-                    repository = factory.getRepository(parameters);
-                    if (repository != null) break;
-                }
-                if (repository==null) throw new RepositoryException("ServiceLoader could not instantiate JCR Repository");
-                configureNodeTypes();
+            Map<String,String> parameters = new HashMap<String,String>();
+            URL configUrl = getConfigurationUrl();
+            RepositoryConfiguration config = RepositoryConfiguration.read(configUrl);
+            Problems problems = config.validate();
+            if (problems.hasErrors()) {
+                throw new RepositoryException(problems.toString());
             }
+            parameters.put("org.modeshape.jcr.URL",configUrl.toExternalForm());
+            for (RepositoryFactory factory : ServiceLoader.load(RepositoryFactory.class)) {
+                theFactory = factory;
+                repository = factory.getRepository(parameters);
+                if (repository != null) break;
+            }
+			if (repository == null) {
+				throw new RepositoryException("ServiceLoader could not instantiate JCR Repository");
+			}
+			configureNodeTypes();
+        } catch (RepositoryException e) {
+        	throw e;
         } catch (Exception e) {
             throw new RepositoryException(e);
+        } finally {
+			if (this.tempConfigDir != null && this.tempConfigDir.isDirectory()) {
+				FileUtils.deleteQuietly(tempConfigDir);
+			}
         }
-
-        return repository;
     }
 
     /**
 	 * Gets the configuration to use for the JCR repository.
      * @throws Exception
 	 */
-	private static URL getConfigurationUrl() throws Exception {
+	private URL getConfigurationUrl() throws Exception {
 		// System properties can be used to set the config URL.  Note that
 		// in the future we'll likely add more configuration types here, so that
 		// the config URL can be specified in interesting ways (JNDI, properties
@@ -96,23 +130,82 @@ public class JCRRepository {
 		CompositeConfiguration config = new CompositeConfiguration();
 		config.addConfiguration(new SystemConfiguration());
 
-		String configUrlStr = config.getString("sramp.modeshape.config.url", "classpath://" + JCRRepository.class.getName() + "/META-INF/modeshape-configs/persistent-sramp-config.json");
-		if (configUrlStr.startsWith("classpath:")) {
+		String configUrl = config.getString("sramp.modeshape.config.url", null);
+		if (configUrl == null) {
+			configUrl = generateConfig();
+		}
+		if (configUrl.startsWith("classpath:")) {
 			Pattern p = Pattern.compile("classpath:/?/?([^/]*)/(.*)$");
-			Matcher matcher = p.matcher(configUrlStr);
+			Matcher matcher = p.matcher(configUrl);
 			if (matcher.matches()) {
 				String className = matcher.group(1);
 				String path = "/" + matcher.group(2);
 				Class<?> clazz = Class.forName(className);
 				URL resourceUrl = clazz.getResource(path);
 				if (resourceUrl == null)
-					throw new Exception("Failed to find config: " + configUrlStr);
+					throw new Exception("Failed to find config: " + configUrl);
 				return resourceUrl;
 			}
-			throw new Exception("Invalid 'classpath' formatted URL: " + configUrlStr);
+			throw new Exception("Invalid 'classpath' formatted URL: " + configUrl);
 		} else {
-			return new URL(configUrlStr);
+			return new URL(configUrl);
 		}
+	}
+
+	/**
+	 * Generates the configuration files used to create and initialize modeshape.
+	 */
+	private String generateConfig() throws Exception {
+		this.tempConfigDir = File.createTempFile("s-ramp-modeshape-config", "dir");
+		if (this.tempConfigDir.isFile()) {
+			this.tempConfigDir.delete();
+		}
+		this.tempConfigDir.mkdirs();
+
+		URL msConfigUrl = getClass().getResource("/META-INF/modeshape-configs/persistent-sramp-config.json");
+		URL isConfigUrl = getClass().getResource("/META-INF/modeshape-configs/infinispan-configuration.xml");
+
+		String msConfig = IOUtils.toString(msConfigUrl);
+		String isConfig = IOUtils.toString(isConfigUrl);
+
+		File dataDir = determineRuntimeDataDir();
+		File tempModeShapeConfigFile = new File(tempConfigDir, "modeshape-config.json");
+		File tempInfinispanConfigFile = new File(tempConfigDir, "infinispan-configuration.xml");
+
+		msConfig = msConfig.replace("${modeshape.jcr.datadir}", dataDir.getCanonicalPath());
+		msConfig = msConfig.replace("${modeshape.cache.config.url}", tempInfinispanConfigFile.getCanonicalPath());
+		isConfig = isConfig.replace("${modeshape.jcr.datadir}", dataDir.getCanonicalPath());
+
+		FileUtils.writeStringToFile(tempModeShapeConfigFile, msConfig);
+		FileUtils.writeStringToFile(tempInfinispanConfigFile, isConfig);
+
+		return tempModeShapeConfigFile.toURI().toURL().toString();
+	}
+
+	/**
+	 * Figures out what the current data directory is.  The data directory will be
+	 * different depending on where we're running.  In an application server this
+	 * code should stive to detect the app server specific data dir.
+	 */
+	private File determineRuntimeDataDir() {
+		// Our property takes precedent if present
+		String rootDataDir = System.getProperty("s-ramp.jcr.data.dir");
+		// Check for JBoss
+		if (rootDataDir == null) {
+			rootDataDir = System.getProperty("jboss.server.data.dir");
+		}
+		// Default to "data/"
+		if (rootDataDir == null) {
+			rootDataDir = "data";
+		}
+
+		File root = new File(rootDataDir);
+		File srampDataDir = new File(root, "s-ramp");
+		if (!srampDataDir.exists()) {
+			srampDataDir.mkdirs();
+		}
+
+		return srampDataDir;
 	}
 
 	/**
@@ -120,23 +213,20 @@ public class JCRRepository {
      * leads to issues where the repo is down, on initialization of the next test. Not using
      * it leads to a successful build. We need to look into this.
      */
-    public static void shutdown(){
-        if (theFactory instanceof org.modeshape.jcr.JcrRepositoryFactory) {
-            try {
-                org.modeshape.jcr.api.RepositoryFactory modeRepo =
-                (org.modeshape.jcr.api.RepositoryFactory)theFactory;
-                Boolean state = modeRepo.shutdown().get();
-                log.info("called shutdown on ModeShape, with resulting state=" + state);
-                repository = null;
-            } catch (InterruptedException e) {
-                // TODO Auto-generated catch block
-                e.printStackTrace();
-            } catch (ExecutionException e) {
-                // TODO Auto-generated catch block
-                e.printStackTrace();
-            }
-        }
-    }
+	private void shutdown() {
+		if (theFactory instanceof org.modeshape.jcr.JcrRepositoryFactory) {
+			try {
+				org.modeshape.jcr.api.RepositoryFactory modeRepo = (org.modeshape.jcr.api.RepositoryFactory) theFactory;
+				Boolean state = modeRepo.shutdown().get();
+				log.info("called shutdown on ModeShape, with resulting state=" + state);
+				repository = null;
+			} catch (InterruptedException e) {
+				log.error(e.getMessage(), e);
+			} catch (ExecutionException e) {
+				log.error(e.getMessage(), e);
+			}
+		}
+	}
 
     /**
      * Convenience method for getting a JCR session from the repo singleton.
@@ -147,7 +237,7 @@ public class JCRRepository {
     public static Session getSession() throws LoginException, NoSuchWorkspaceException, RepositoryException {
         //Credentials cred = new SimpleCredentials(USER, PWD);
         AnonymousCredentials cred = new AnonymousCredentials();
-        return getInstance().login(cred, WORKSPACE_NAME);
+        return getInstance().get().login(cred, WORKSPACE_NAME);
     }
 
     /**
@@ -167,7 +257,7 @@ public class JCRRepository {
     /**
      * Called to configure the custom JCR node types.
      */
-    private static void configureNodeTypes() throws RepositoryException {
+    private void configureNodeTypes() throws RepositoryException {
         Session session = null;
         InputStream is = null;
         try {

--- a/s-ramp-repository-jcr/src/main/resources/META-INF/modeshape-configs/infinispan-configuration.xml
+++ b/s-ramp-repository-jcr/src/main/resources/META-INF/modeshape-configs/infinispan-configuration.xml
@@ -13,7 +13,7 @@
             <loader class="org.infinispan.loaders.bdbje.BdbjeCacheStore"
                    fetchPersistentState="true" purgeOnStartup="false">
                 <properties>
-                    <property name="location" value="target/repos/content" />
+                    <property name="location" value="${modeshape.jcr.datadir}/content" />
                 </properties>
             </loader>
         </loaders>

--- a/s-ramp-repository-jcr/src/main/resources/META-INF/modeshape-configs/persistent-sramp-config.json
+++ b/s-ramp-repository-jcr/src/main/resources/META-INF/modeshape-configs/persistent-sramp-config.json
@@ -12,18 +12,18 @@
         }
     },
     "storage" : {
-        "cacheConfiguration" : "infinispan-configuration.xml",
+        "cacheConfiguration" : "${modeshape.cache.config.url}",
         "cacheName" : "persisted-repository",
         "binaryStorage" : {
             "type" : "file",
-            "directory": "target/repos/binary",
+            "directory": "${modeshape.jcr.datadir}/binary",
             "minimumBinarySizeInBytes" : 999
         }
     },
     "query" : {
         "indexStorage" : {
             "type" : "filesystem",
-            "location" : "target/repos/index",
+            "location" : "${modeshape.jcr.datadir}/index",
             "lockingStrategy" : "simple",
             "fileSystemAccessType" : "auto"
         }

--- a/s-ramp-repository/src/main/java/org/overlord/sramp/repository/PersistenceFactory.java
+++ b/s-ramp-repository/src/main/java/org/overlord/sramp/repository/PersistenceFactory.java
@@ -18,10 +18,15 @@ package org.overlord.sramp.repository;
 import java.util.ServiceLoader;
 
 
+/**
+ * Factory used to create an instance of an S-RAMP {@link PersistenceManager}.
+ */
 public class PersistenceFactory {
 
+    /**
+     * Return a new instance of the persistence manager.
+     */
     public static PersistenceManager newInstance() {
-
         for (PersistenceManager manager : ServiceLoader.load(PersistenceManager.class)) {
             return manager;
         }

--- a/s-ramp-wagon/src/main/java/org/overlord/sramp/wagon/SrampWagon.java
+++ b/s-ramp-wagon/src/main/java/org/overlord/sramp/wagon/SrampWagon.java
@@ -416,7 +416,7 @@ public class SrampWagon extends StreamWagon {
 						SrampModelUtils.setCustomProperty(metaData, "maven.parent-artifactId", gavInfo.getArtifactId());
 						SrampModelUtils.setCustomProperty(metaData, "maven.parent-version", gavInfo.getVersion());
 						SrampModelUtils.setCustomProperty(metaData, "maven.parent-type", gavInfo.getType());
-						SrampModelUtils.addGenericRelationship(metaData, "mavenParent", parentUUID);
+						SrampModelUtils.addGenericRelationship(metaData, "expandedFromDocument", parentUUID);
 						return metaData;
 					}
 				});


### PR DESCRIPTION
The data directory used by the modeshape jcr persistence provider is now
configurable via a system property.  In addition, when the property is
not defined, a best-effort to determine a reasonable location is made. 
Currently this works well in JBoss, and that's about it.
