### PR TITLE
(sramp-75) Improvements to the Atom API client

### DIFF
--- a/s-ramp-atom-core/src/main/java/org/overlord/sramp/atom/visitors/ArtifactToSummaryAtomEntryVisitor.java
+++ b/s-ramp-atom-core/src/main/java/org/overlord/sramp/atom/visitors/ArtifactToSummaryAtomEntryVisitor.java
@@ -47,6 +47,7 @@ public class ArtifactToSummaryAtomEntryVisitor extends ArtifactVisitorAdapter {
 
 	/**
 	 * Constructor.
+	 * @param baseUrl
 	 */
 	public ArtifactToSummaryAtomEntryVisitor(String baseUrl) {
 	    this.baseUrl = baseUrl;
@@ -54,6 +55,7 @@ public class ArtifactToSummaryAtomEntryVisitor extends ArtifactVisitorAdapter {
 
 	/**
 	 * Constructor.
+	 * @param baseUrl
 	 * @param propNames
 	 */
 	public ArtifactToSummaryAtomEntryVisitor(String baseUrl, Set<String> propNames) {
@@ -109,7 +111,7 @@ public class ArtifactToSummaryAtomEntryVisitor extends ArtifactVisitorAdapter {
 				entry.getAuthors().add(new Person(artifact.getCreatedBy()));
 			if (artifact.getDescription() != null)
 				entry.setSummary(artifact.getDescription());
-			
+
 			String atomLink = baseUrl + "/s-ramp/"
 					+ artifactType.getModel() + "/"
 					+ artifactType.getType() + "/" + artifact.getUuid();

--- a/s-ramp-client/src/main/java/org/overlord/sramp/client/brms/BrmsPkgToSramp.java
+++ b/s-ramp-client/src/main/java/org/overlord/sramp/client/brms/BrmsPkgToSramp.java
@@ -20,9 +20,7 @@ import org.jboss.resteasy.client.ClientRequest;
 import org.jboss.resteasy.client.ClientRequestFactory;
 import org.jboss.resteasy.client.ClientResponse;
 import org.jboss.resteasy.client.core.executors.ApacheHttpClient4Executor;
-import org.jboss.resteasy.plugins.providers.atom.Entry;
 import org.overlord.sramp.ArtifactType;
-import org.overlord.sramp.atom.SrampAtomUtils;
 import org.overlord.sramp.atom.services.brms.Assets;
 import org.overlord.sramp.atom.services.brms.BrmsConstants;
 import org.overlord.sramp.atom.services.brms.Packages;
@@ -132,13 +130,13 @@ public class BrmsPkgToSramp {
         assetsProperty.setPropertyValue(assetsXml);
         userDefinedArtifactType.getProperty().add(assetsProperty);
 
-        System.out.println("Reading " + pkgName + " from url " + urlStr );
+        System.out.println("Reading " + pkgName + " from url " + urlStr);
         ClientResponse<InputStream> pkgResponse = getInputStream(urlStr);
         InputStream content = pkgResponse.getEntity();
         SrampAtomApiClient client = new SrampAtomApiClient("http://localhost:8880/s-ramp-atom/s-ramp");
-        Entry entry = client.uploadArtifact(userDefinedArtifactType, content);
+        BaseArtifactType artifact = client.uploadArtifact(userDefinedArtifactType, content);
         IOUtils.closeQuietly(content);
-        System.out.println("Uploaded " + pkgName + " UUID=" + entry.getId().toString());
+        System.out.println("Uploaded " + pkgName + " UUID=" + artifact.getUuid());
 
         // Now obtaining the assets in the this package, and upload those
         // TODO set relationship to parent pkg
@@ -163,9 +161,8 @@ public class BrmsPkgToSramp {
                 baseArtifactType.setName(fileName);
                 baseArtifactType.setUuid(uuid);
 
-                Entry assetEntry = client.uploadArtifact(baseArtifactType, assetInputStream);
+                BaseArtifactType assetArtifact = client.uploadArtifact(baseArtifactType, assetInputStream);
                 IOUtils.closeQuietly(assetInputStream);
-                BaseArtifactType assetArtifact = SrampAtomUtils.unwrapSrampArtifact(assetEntry);
                 System.out.println("Uploaded asset " + assetArtifact.getName() + " " + assetArtifact.getUuid());
             }
         }

--- a/s-ramp-client/src/main/java/org/overlord/sramp/client/query/ArtifactSummary.java
+++ b/s-ramp-client/src/main/java/org/overlord/sramp/client/query/ArtifactSummary.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2012 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.overlord.sramp.client.query;
+
+import java.util.Date;
+
+import org.jboss.resteasy.plugins.providers.atom.Entry;
+import org.overlord.sramp.ArtifactType;
+import org.overlord.sramp.atom.SrampAtomUtils;
+
+/**
+ * Models a summary of a single S-RAMP artifact from a Feed (result of an
+ * S-RAMP query).
+ *
+ * @author eric.wittmann@redhat.com
+ */
+public class ArtifactSummary {
+
+	private Entry entry;
+
+	/**
+	 * Constructor.
+	 * @param entry
+	 */
+	public ArtifactSummary(Entry entry) {
+		this.entry = entry;
+	}
+
+	/**
+	 * @return the artifact type
+	 */
+	public ArtifactType getType() {
+		return SrampAtomUtils.getArtifactType(entry);
+	}
+
+	/**
+	 * @return the artifact's uuid
+	 */
+	public String getUuid() {
+		return entry.getId().toString();
+	}
+
+	/**
+	 * @return the artifact's last modified timestamp
+	 */
+	public Date getLastModifiedTimestamp() {
+		return entry.getUpdated();
+	}
+
+	/**
+	 * @return the artifact's name
+	 */
+	public String getName() {
+		return entry.getTitle();
+	}
+
+	/**
+	 * @return the artifact's created timestamp
+	 */
+	public Date getCreatedTimestamp() {
+		return entry.getPublished();
+	}
+
+	/**
+	 * @return the artifact's created by
+	 */
+	public String getCreatedBy() {
+		return entry.getAuthors().get(0).getName();
+	}
+
+	/**
+	 * @return the artifact's description
+	 */
+	public String getDescription() {
+		return entry.getSummary();
+	}
+
+
+}

--- a/s-ramp-client/src/main/java/org/overlord/sramp/client/query/QueryResultSet.java
+++ b/s-ramp-client/src/main/java/org/overlord/sramp/client/query/QueryResultSet.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2012 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.overlord.sramp.client.query;
+
+import java.util.Iterator;
+
+import org.jboss.resteasy.plugins.providers.atom.Entry;
+import org.jboss.resteasy.plugins.providers.atom.Feed;
+
+/**
+ * An instance of this class is returned by the Atom API client when consumers
+ * call the query methods.
+ *
+ * @author eric.wittmann@redhat.com
+ */
+public class QueryResultSet implements Iterable<ArtifactSummary> {
+
+	private Feed currentFeed;
+
+	/**
+	 * Constructor.
+	 * @param feed
+	 */
+	public QueryResultSet(Feed feed) {
+		this.currentFeed = feed;
+	}
+
+	/**
+	 * Returns the number of artifacts that matched the query.
+	 */
+	public long size() {
+		return this.currentFeed.getEntries().size();
+	}
+
+	/**
+	 * Gets an item at the given index.
+	 * @param index
+	 */
+	public ArtifactSummary get(int index) {
+		if (index >= currentFeed.getEntries().size()) {
+			return null;
+		} else {
+			return new ArtifactSummary(currentFeed.getEntries().get(index));
+		}
+	}
+
+	/**
+	 * @see java.lang.Iterable#iterator()
+	 */
+	@Override
+	public Iterator<ArtifactSummary> iterator() {
+		return new DelegatingIterator(currentFeed.getEntries().iterator());
+	}
+
+
+	/**
+	 * Delegates iteration to an underlying impl, simply converts the objects
+	 * into the correct type.
+	 *
+	 * @author eric.wittmann@redhat.com
+	 */
+	private static class DelegatingIterator implements Iterator<ArtifactSummary> {
+
+		private Iterator<Entry> delegate;
+
+		/**
+		 * Constructor.
+		 * @param delegate
+		 */
+		public DelegatingIterator(Iterator<Entry> delegate) {
+			this.delegate = delegate;
+		}
+
+		/**
+		 * @see java.util.Iterator#hasNext()
+		 */
+		@Override
+		public boolean hasNext() {
+			return delegate.hasNext();
+		}
+
+		/**
+		 * @see java.util.Iterator#next()
+		 */
+		@Override
+		public ArtifactSummary next() {
+			return new ArtifactSummary(delegate.next());
+		}
+
+		/**
+		 * @see java.util.Iterator#remove()
+		 */
+		@Override
+		public void remove() {
+			throw new UnsupportedOperationException();
+		}
+	}
+}

--- a/s-ramp-client/src/main/java/org/overlord/sramp/client/shell/commands/core/GetContentCommand.java
+++ b/s-ramp-client/src/main/java/org/overlord/sramp/client/shell/commands/core/GetContentCommand.java
@@ -100,8 +100,7 @@ public class GetContentCommand extends AbstractShellCommand {
 			}
 			Entry entry = feed.getEntries().get(feedIdx);
 			String artifactUUID = entry.getId().toString();
-			Entry fullArtifactEntry = client.getFullArtifactEntry(SrampAtomUtils.getArtifactType(entry), artifactUUID);
-			artifact = SrampAtomUtils.unwrapSrampArtifact(fullArtifactEntry);
+			artifact = client.getArtifactMetaData(SrampAtomUtils.getArtifactType(entry), artifactUUID);
 		} else if ("uuid".equals(idType)) {
 //			String artifactUUID = artifactIdArg.substring(artifactIdArg.indexOf(':') + 1);
 //			artifact = getArtifactMetaDataByUUID(client, artifactUUID);

--- a/s-ramp-client/src/main/java/org/overlord/sramp/client/shell/commands/core/GetMetaDataCommand.java
+++ b/s-ramp-client/src/main/java/org/overlord/sramp/client/shell/commands/core/GetMetaDataCommand.java
@@ -19,11 +19,10 @@ import java.io.File;
 
 import javax.xml.namespace.QName;
 
-import org.jboss.resteasy.plugins.providers.atom.Entry;
-import org.jboss.resteasy.plugins.providers.atom.Feed;
-import org.overlord.sramp.atom.SrampAtomUtils;
 import org.overlord.sramp.atom.archive.SrampArchiveJaxbUtils;
 import org.overlord.sramp.client.SrampAtomApiClient;
+import org.overlord.sramp.client.query.ArtifactSummary;
+import org.overlord.sramp.client.query.QueryResultSet;
 import org.overlord.sramp.client.shell.AbstractShellCommand;
 import org.overlord.sramp.client.shell.ShellContext;
 import org.overlord.sramp.client.shell.commands.InvalidCommandArgumentException;
@@ -92,16 +91,14 @@ public class GetMetaDataCommand extends AbstractShellCommand {
 		BaseArtifactType artifact = null;
 		String idType = artifactIdArg.substring(0, artifactIdArg.indexOf(':'));
 		if ("feed".equals(idType)) {
-			Feed feed = (Feed) context.getVariable(feedVarName);
-			context.setVariable(feedVarName, feed);
+			QueryResultSet rset = (QueryResultSet) context.getVariable(feedVarName);
 			int feedIdx = Integer.parseInt(artifactIdArg.substring(artifactIdArg.indexOf(':')+1)) - 1;
-			if (feedIdx < 0 || feedIdx >= feed.getEntries().size()) {
+			if (feedIdx < 0 || feedIdx >= rset.size()) {
 				throw new InvalidCommandArgumentException(0, "Feed index out of range.");
 			}
-			Entry entry = feed.getEntries().get(feedIdx);
-			String artifactUUID = entry.getId().toString();
-			Entry fullArtifactEntry = client.getFullArtifactEntry(SrampAtomUtils.getArtifactType(entry), artifactUUID);
-			artifact = SrampAtomUtils.unwrapSrampArtifact(fullArtifactEntry);
+			ArtifactSummary summary = rset.get(feedIdx);
+			String artifactUUID = summary.getUuid();
+			artifact = client.getArtifactMetaData(summary.getType(), artifactUUID);
 		} else if ("uuid".equals(idType)) {
 //			String artifactUUID = artifactIdArg.substring(artifactIdArg.indexOf(':') + 1);
 //			artifact = getArtifactMetaDataByUUID(client, artifactUUID);

--- a/s-ramp-client/src/main/java/org/overlord/sramp/client/shell/commands/core/QueryCommand.java
+++ b/s-ramp-client/src/main/java/org/overlord/sramp/client/shell/commands/core/QueryCommand.java
@@ -17,11 +17,10 @@ package org.overlord.sramp.client.shell.commands.core;
 
 import javax.xml.namespace.QName;
 
-import org.jboss.resteasy.plugins.providers.atom.Entry;
-import org.jboss.resteasy.plugins.providers.atom.Feed;
 import org.overlord.sramp.ArtifactType;
-import org.overlord.sramp.atom.SrampAtomUtils;
 import org.overlord.sramp.client.SrampAtomApiClient;
+import org.overlord.sramp.client.query.ArtifactSummary;
+import org.overlord.sramp.client.query.QueryResultSet;
 import org.overlord.sramp.client.shell.AbstractShellCommand;
 import org.overlord.sramp.client.shell.ShellContext;
 
@@ -67,16 +66,17 @@ public class QueryCommand extends AbstractShellCommand {
 		String queryArg = this.requiredArgument(0, "Please specify a valid S-RAMP query.");
 		QName varName = new QName("s-ramp", "client");
 		SrampAtomApiClient client = (SrampAtomApiClient) context.getVariable(varName);
-		Feed feed = client.query(queryArg);
+		QueryResultSet rset = client.query(queryArg);
 		int entryIndex = 1;
-		System.out.printf("Atom Feed (%1$d entries)\n", feed.getEntries().size());
+		System.out.printf("Atom Feed (%1$d entries)\n", rset.size());
 		System.out.printf("  Idx                 Type Name\n");
 		System.out.printf("  ---                 ---- ----\n");
-		for (Entry entry : feed.getEntries()) {
-			ArtifactType type = SrampAtomUtils.getArtifactType(entry);
-			System.out.printf("  %1$3d %2$20s %3$-40s\n", entryIndex++, type.getArtifactType().getType().toString(), entry.getTitle());
+		for (ArtifactSummary summary : rset) {
+			ArtifactType type = summary.getType();
+			System.out.printf("  %1$3d %2$20s %3$-40s\n", entryIndex++, type.getArtifactType().getType()
+					.toString(), summary.getName());
 		}
-		context.setVariable(new QName("s-ramp", "feed"), feed);
+		context.setVariable(new QName("s-ramp", "feed"), rset);
 	}
 
 }

--- a/s-ramp-demos/s-ramp-demos-archive-package/src/main/java/org/overlord/sramp/demos/archivepkg/ArchivePackageDemo.java
+++ b/s-ramp-demos/s-ramp-demos-archive-package/src/main/java/org/overlord/sramp/demos/archivepkg/ArchivePackageDemo.java
@@ -18,10 +18,10 @@ package org.overlord.sramp.demos.archivepkg;
 import java.io.InputStream;
 import java.util.Map;
 
-import org.jboss.resteasy.plugins.providers.atom.Entry;
-import org.jboss.resteasy.plugins.providers.atom.Feed;
 import org.overlord.sramp.atom.archive.SrampArchive;
 import org.overlord.sramp.client.SrampAtomApiClient;
+import org.overlord.sramp.client.query.ArtifactSummary;
+import org.overlord.sramp.client.query.QueryResultSet;
 import org.s_ramp.xmlns._2010.s_ramp.BaseArtifactType;
 import org.s_ramp.xmlns._2010.s_ramp.WsdlDocument;
 import org.s_ramp.xmlns._2010.s_ramp.XsdDocument;
@@ -130,10 +130,10 @@ public class ArchivePackageDemo {
 
 		// Now query the S-RAMP repository (for the Schemas only)
 		System.out.print("Querying the S-RAMP repository for Schemas...");
-		Feed feed = client.query("/s-ramp/xsd/XsdDocument");
-		System.out.println("success: " + feed.getEntries().size() + " Schemas found:");
-		for (Entry entry : feed.getEntries()) {
-			System.out.println("\t * " + entry.getTitle() + " (" + entry.getId() + ")");
+		QueryResultSet rset = client.query("/s-ramp/xsd/XsdDocument");
+		System.out.println("success: " + rset.size() + " Schemas found:");
+		for (ArtifactSummary summary : rset) {
+			System.out.println("\t * " + summary.getName() + " (" + summary.getUuid() + ")");
 		}
 
 		System.out.println("\n*** Demo Completed Successfully ***\n\n");

--- a/s-ramp-demos/s-ramp-demos-query/src/main/java/org/overlord/sramp/demos/query/QueryDemo.java
+++ b/s-ramp-demos/s-ramp-demos-query/src/main/java/org/overlord/sramp/demos/query/QueryDemo.java
@@ -15,9 +15,9 @@
  */
 package org.overlord.sramp.demos.query;
 
-import org.jboss.resteasy.plugins.providers.atom.Feed;
 import org.overlord.sramp.atom.archive.SrampArchive;
 import org.overlord.sramp.client.SrampAtomApiClient;
+import org.overlord.sramp.client.query.QueryResultSet;
 
 /**
  * Demonstrates a number of different queries supported by S-RAMP.  Also, more generally,
@@ -67,33 +67,33 @@ public class QueryDemo {
 
 		// First, a simple query for the XSDs.
 		System.out.print("Querying the S-RAMP repository for Schemas...");
-		Feed feed = client.query("/s-ramp/xsd/XsdDocument");
-		System.out.println("success: " + feed.getEntries().size() + " Schema(s) found (expected AT LEAST 2)");
+		QueryResultSet rset = client.query("/s-ramp/xsd/XsdDocument");
+		System.out.println("success: " + rset.size() + " Schema(s) found (expected AT LEAST 2)");
 
 		// Now a simple query for the WSDLs.
 		System.out.print("Querying the S-RAMP repository for WSDLs...");
-		feed = client.query("/s-ramp/wsdl/WsdlDocument");
-		System.out.println("success: " + feed.getEntries().size() + " WSDL(s) found (expected AT LEAST 1)");
+		rset = client.query("/s-ramp/wsdl/WsdlDocument");
+		System.out.println("success: " + rset.size() + " WSDL(s) found (expected AT LEAST 1)");
 
 		// Try searching for everything with a version of 1.1 (should be at least 2)
 		System.out.print("Querying the S-RAMP repository for all artifacts version 1.1...");
-		feed = client.query("/s-ramp[@version = '1.1']");
-		System.out.println("success: " + feed.getEntries().size() + " artifact(s) found (expected AT LEAST 2)");
+		rset = client.query("/s-ramp[@version = '1.1']");
+		System.out.println("success: " + rset.size() + " artifact(s) found (expected AT LEAST 2)");
 
 		// Try searching for everything with a version of 1.2 (should be at least 1)
 		System.out.print("Querying the S-RAMP repository for all artifacts version 1.2...");
-		feed = client.query("/s-ramp[@version = '1.2']");
-		System.out.println("success: " + feed.getEntries().size() + " artifact(s) found (expected AT LEAST 1)");
+		rset = client.query("/s-ramp[@version = '1.2']");
+		System.out.println("success: " + rset.size() + " artifact(s) found (expected AT LEAST 1)");
 
 		// Find just a single artifact by name and version
 		System.out.print("Querying the S-RAMP repository for a unique artifact by name + version...");
-		feed = client.query("/s-ramp[@name = 'wsrm-1.1-schema-200702.xsd' and @version = '1.1']");
-		System.out.println("success: " + feed.getEntries().size() + " artifact(s) found (expected 1)");
+		rset = client.query("/s-ramp[@name = 'wsrm-1.1-schema-200702.xsd' and @version = '1.1']");
+		System.out.println("success: " + rset.size() + " artifact(s) found (expected 1)");
 
 		// If we search for conflicting meta-data we should get 0 results, right?
 		System.out.print("Querying the S-RAMP repository conflicting meta data...");
-		feed = client.query("/s-ramp[@name = 'wsrm-1.1-schema-200702.xsd' and @version = '1.2']");
-		System.out.println("success: " + feed.getEntries().size() + " artifact(s) found (expected 0)");
+		rset = client.query("/s-ramp[@name = 'wsrm-1.1-schema-200702.xsd' and @version = '1.2']");
+		System.out.println("success: " + rset.size() + " artifact(s) found (expected 0)");
 
 		System.out.println("\n*** Demo Completed Successfully ***\n\n");
 		Thread.sleep(3000);

--- a/s-ramp-demos/s-ramp-demos-simple-client/src/main/java/org/overlord/sramp/demos/simpleclient/SimpleClientDemo.java
+++ b/s-ramp-demos/s-ramp-demos-simple-client/src/main/java/org/overlord/sramp/demos/simpleclient/SimpleClientDemo.java
@@ -17,12 +17,11 @@ package org.overlord.sramp.demos.simpleclient;
 
 import java.io.InputStream;
 
-import org.jboss.resteasy.plugins.providers.atom.Entry;
-import org.jboss.resteasy.plugins.providers.atom.Feed;
 import org.overlord.sramp.ArtifactType;
 import org.overlord.sramp.SrampModelUtils;
-import org.overlord.sramp.atom.SrampAtomUtils;
 import org.overlord.sramp.client.SrampAtomApiClient;
+import org.overlord.sramp.client.query.ArtifactSummary;
+import org.overlord.sramp.client.query.QueryResultSet;
 import org.s_ramp.xmlns._2010.s_ramp.BaseArtifactType;
 
 /**
@@ -68,11 +67,10 @@ public class SimpleClientDemo {
 
 				// Upload that content to S-RAMP
 				System.out.print("\tUploading artifact " + file + "...");
-				Entry newArtifact = client.uploadArtifact(type, is, file);
+				BaseArtifactType artifact = client.uploadArtifact(type, is, file);
 				System.out.println("done.");
 
 				// Update the artifact meta-data (set the version and add a custom property)
-				BaseArtifactType artifact = SrampAtomUtils.unwrapSrampArtifact(newArtifact);
 				artifact.setVersion("1.1");
 				SrampModelUtils.setCustomProperty(artifact, "demo", "simple-client");
 
@@ -87,10 +85,10 @@ public class SimpleClientDemo {
 
 		// Now query the S-RAMP repository (for the Schemas only)
 		System.out.print("Querying the S-RAMP repository for Schemas...");
-		Feed feed = client.query("/s-ramp/xsd/XsdDocument");
-		System.out.println("success: " + feed.getEntries().size() + " Schemas found:");
-		for (Entry entry : feed.getEntries()) {
-			System.out.println("\t * " + entry.getTitle() + " (" + entry.getId() + ")");
+		QueryResultSet rset = client.query("/s-ramp/xsd/XsdDocument");
+		System.out.println("success: " + rset.size() + " Schemas found:");
+		for (ArtifactSummary entry : rset) {
+			System.out.println("\t * " + entry.getName() + " (" + entry.getUuid() + ")");
 		}
 
 		System.out.println("\n*** Demo Completed Successfully ***\n\n");

--- a/s-ramp-wagon/src/main/java/org/overlord/sramp/wagon/SrampWagon.java
+++ b/s-ramp-wagon/src/main/java/org/overlord/sramp/wagon/SrampWagon.java
@@ -43,11 +43,8 @@ import org.apache.maven.wagon.resource.Resource;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.logging.Logger;
-import org.jboss.resteasy.plugins.providers.atom.Entry;
-import org.jboss.resteasy.plugins.providers.atom.Feed;
 import org.overlord.sramp.ArtifactType;
 import org.overlord.sramp.SrampModelUtils;
-import org.overlord.sramp.atom.SrampAtomUtils;
 import org.overlord.sramp.atom.archive.SrampArchive;
 import org.overlord.sramp.atom.archive.SrampArchiveEntry;
 import org.overlord.sramp.atom.archive.SrampArchiveException;
@@ -57,6 +54,8 @@ import org.overlord.sramp.client.SrampClientException;
 import org.overlord.sramp.client.jar.DefaultMetaDataFactory;
 import org.overlord.sramp.client.jar.DiscoveredArtifact;
 import org.overlord.sramp.client.jar.JarToSrampArchive;
+import org.overlord.sramp.client.query.ArtifactSummary;
+import org.overlord.sramp.client.query.QueryResultSet;
 import org.overlord.sramp.wagon.models.MavenGavInfo;
 import org.overlord.sramp.wagon.util.DevNullOutputStream;
 import org.s_ramp.xmlns._2010.s_ramp.BaseArtifactType;
@@ -384,7 +383,7 @@ public class SrampWagon extends StreamWagon {
 			// the artifact to the repository.
 			if (artifact != null) {
 				this.archive.addEntry(gavInfo.getFullName(), artifact, null);
-				client.updateArtifact(artifact, resourceInputStream);
+				client.updateArtifactContent(artifact, resourceInputStream);
 				if (shouldExpand(gavInfo)) {
 					final String parentUUID = artifact.getUuid();
 					cleanExpandedArtifacts(client, parentUUID);
@@ -392,8 +391,7 @@ public class SrampWagon extends StreamWagon {
 			} else {
 				// Upload the content, then add the maven properties to the artifact
 				// as meta-data
-				Entry entry = client.uploadArtifact(artifactType, resourceInputStream, gavInfo.getName());
-				artifact = SrampAtomUtils.unwrapSrampArtifact(artifactType, entry);
+				artifact = client.uploadArtifact(artifactType, resourceInputStream, gavInfo.getName());
 				SrampModelUtils.setCustomProperty(artifact, "maven.groupId", gavInfo.getGroupId());
 				SrampModelUtils.setCustomProperty(artifact, "maven.artifactId", gavInfo.getArtifactId());
 				SrampModelUtils.setCustomProperty(artifact, "maven.version", gavInfo.getVersion());
@@ -444,13 +442,13 @@ public class SrampWagon extends StreamWagon {
 		String query = String.format("/s-ramp[mavenParent[@uuid = '%1$s']]", parentUUID);
 		boolean done = false;
 		while (!done) {
-			Feed feed = client.query(query, 0, 20, "name", true);
-			if (feed.getEntries().size() == 0) {
+			QueryResultSet rset = client.query(query, 0, 20, "name", true);
+			if (rset.size() == 0) {
 				done = true;
 			} else {
-				for (Entry entry : feed.getEntries()) {
-					ArtifactType artifactType = SrampAtomUtils.getArtifactType(entry);
-					String uuid = entry.getId().toString();
+				for (ArtifactSummary entry : rset) {
+					ArtifactType artifactType = entry.getType();
+					String uuid = entry.getUuid();
 					client.deleteArtifact(uuid, artifactType);
 				}
 			}
@@ -527,13 +525,12 @@ public class SrampWagon extends StreamWagon {
 			query = String.format("/s-ramp[@maven.groupId = '%1$s' and @maven.artifactId = '%2$s' and @maven.version = '%3$s' and @maven.classifier = '%4$s' and @maven.type = '%5$s']",
 					gavInfo.getGroupId(), gavInfo.getArtifactId(), gavInfo.getVersion(), gavInfo.getClassifier(), gavInfo.getType());
 		}
-		Feed feed = client.query(query);
-		if (feed.getEntries().size() > 0) {
-			for (Entry entry : feed.getEntries()) {
-				String uuid = entry.getId().toString();
-				ArtifactType artifactType = SrampAtomUtils.getArtifactType(entry);
-				entry = client.getFullArtifactEntry(artifactType, uuid);
-				BaseArtifactType arty = SrampAtomUtils.unwrapSrampArtifact(artifactType, entry);
+		QueryResultSet rset = client.query(query);
+		if (rset.size() > 0) {
+			for (ArtifactSummary summary : rset) {
+				String uuid = summary.getUuid();
+				ArtifactType artifactType = summary.getType();
+				BaseArtifactType arty = client.getArtifactMetaData(artifactType, uuid);
 				// If no classifier in the GAV info, only return the artifact that also has no classifier
 				if (gavInfo.getClassifier() == null) {
 					String artyClassifier = SrampModelUtils.getCustomProperty(arty, "maven.classifier");
@@ -565,14 +562,11 @@ public class SrampWagon extends StreamWagon {
 			throws SrampAtomException, SrampClientException, JAXBException {
 		String artifactType = gavInfo.getGroupId().substring(gavInfo.getGroupId().indexOf('.') + 1);
 		String uuid = gavInfo.getArtifactId();
-		Entry entry = null;
 		try {
-			entry = client.getFullArtifactEntry(ArtifactType.valueOf(artifactType), uuid);
+			return client.getArtifactMetaData(ArtifactType.valueOf(artifactType), uuid);
 		} catch (Throwable t) {
 			logger.debug(t.getMessage());
 		}
-		if (entry != null)
-			return SrampAtomUtils.unwrapSrampArtifact(ArtifactType.valueOf(artifactType), entry);
 		return null;
 	}
 

--- a/s-ramp-wagon/src/test/java/org/overlord/sramp/wagon/SrampWagonTest.java
+++ b/s-ramp-wagon/src/test/java/org/overlord/sramp/wagon/SrampWagonTest.java
@@ -28,7 +28,6 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.maven.wagon.repository.Repository;
 import org.codehaus.plexus.logging.console.ConsoleLogger;
-import org.jboss.resteasy.plugins.providers.atom.Feed;
 import org.jboss.resteasy.test.BaseResourceTest;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -42,6 +41,7 @@ import org.overlord.sramp.atom.services.BatchResource;
 import org.overlord.sramp.atom.services.FeedResource;
 import org.overlord.sramp.atom.services.QueryResource;
 import org.overlord.sramp.client.SrampAtomApiClient;
+import org.overlord.sramp.client.query.QueryResultSet;
 import org.overlord.sramp.repository.PersistenceFactory;
 import org.overlord.sramp.repository.jcr.JCRRepository;
 import org.overlord.sramp.repository.jcr.JCRRepositoryCleaner;
@@ -121,14 +121,14 @@ public class SrampWagonTest extends BaseResourceTest {
 		// Now that we've deployed the artifacts, do some queries to make sure we put away
 		// what we intended.
 		SrampAtomApiClient client = new SrampAtomApiClient(generateURL("/s-ramp/"));
-		Feed feed = client.query("/s-ramp/core/Document");
-		Assert.assertEquals(2, feed.getEntries().size());
-		feed = client.query("/s-ramp/xsd/XsdDocument");
-		Assert.assertEquals(3, feed.getEntries().size());
-		feed = client.query("/s-ramp/wsdl/WsdlDocument");
-		Assert.assertEquals(1, feed.getEntries().size());
-		feed = client.query("/s-ramp[expandedFromDocument]");
-		Assert.assertEquals(4, feed.getEntries().size());
+		QueryResultSet rset = client.query("/s-ramp/core/Document");
+		Assert.assertEquals(2, rset.size());
+		rset = client.query("/s-ramp/xsd/XsdDocument");
+		Assert.assertEquals(3, rset.size());
+		rset = client.query("/s-ramp/wsdl/WsdlDocument");
+		Assert.assertEquals(1, rset.size());
+		rset = client.query("/s-ramp[expandedFromDocument]");
+		Assert.assertEquals(4, rset.size());
 
 		// Upload the content again (to make sure the expanded artifacts get deleted and re-added)
 		// TODO re-enable this once I figure out why I am getting a referential integrity error
@@ -146,14 +146,14 @@ public class SrampWagonTest extends BaseResourceTest {
 
 		// Now all the same assertions.
 		/*
-		feed = client.query("/s-ramp/core/Document");
-		Assert.assertEquals(2, feed.getEntries().size());
-		feed = client.query("/s-ramp/xsd/XsdDocument");
-		Assert.assertEquals(3, feed.getEntries().size());
-		feed = client.query("/s-ramp/wsdl/WsdlDocument");
-		Assert.assertEquals(1, feed.getEntries().size());
-		feed = client.query("/s-ramp[mavenParent]");
-		Assert.assertEquals(4, feed.getEntries().size());
+		rset = client.query("/s-ramp/core/Document");
+		Assert.assertEquals(2, rset.size());
+		rset = client.query("/s-ramp/xsd/XsdDocument");
+		Assert.assertEquals(3, rset.size());
+		rset = client.query("/s-ramp/wsdl/WsdlDocument");
+		Assert.assertEquals(1, rset.size());
+		rset = client.query("/s-ramp[mavenParent]");
+		Assert.assertEquals(4, rset.size());
 		*/
 
 	}


### PR DESCRIPTION
The atom API client now hides all the Atom related details from
consumers.  Consumers now deal exclusively with S-RAMP data structures. 
There is no longer a need to deal with the Atom objects (Feed, Entry,
etc).
