### PR TITLE
(sramp-122) Additional error logging in the Atom server layer

### DIFF
--- a/s-ramp-atom/src/main/java/org/overlord/sramp/atom/services/AbstractFeedResource.java
+++ b/s-ramp-atom/src/main/java/org/overlord/sramp/atom/services/AbstractFeedResource.java
@@ -36,12 +36,16 @@ import org.overlord.sramp.repository.query.ArtifactSet;
 import org.overlord.sramp.repository.query.SrampQuery;
 import org.overlord.sramp.visitors.ArtifactVisitorHelper;
 import org.s_ramp.xmlns._2010.s_ramp.BaseArtifactType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
  * Base class for all resources that respond with Atom Feeds.
  */
 public abstract class AbstractFeedResource {
+
+	private static Logger logger = LoggerFactory.getLogger(AbstractFeedResource.class);
 
 	/**
 	 * Constructor.
@@ -82,6 +86,7 @@ public abstract class AbstractFeedResource {
 			addPaginationLinks(feed, artifactSet, query, startIndex, count, orderBy, ascending);
 			return feed;
 		} catch (Throwable e) {
+			logger.error("Error trying to create an Artifact Feed.", e);
 			throw new SrampAtomException(e);
 		} finally {
 			if (artifactSet != null)

--- a/s-ramp-atom/src/main/java/org/overlord/sramp/atom/services/BatchResource.java
+++ b/s-ramp-atom/src/main/java/org/overlord/sramp/atom/services/BatchResource.java
@@ -43,6 +43,8 @@ import org.overlord.sramp.repository.PersistenceFactory;
 import org.overlord.sramp.repository.PersistenceManager;
 import org.overlord.sramp.visitors.ArtifactVisitorHelper;
 import org.s_ramp.xmlns._2010.s_ramp.BaseArtifactType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The JAX-RS resource that handles pushing artifacts into the repository in batches.  The
@@ -54,7 +56,10 @@ import org.s_ramp.xmlns._2010.s_ramp.BaseArtifactType;
 @Path("/s-ramp")
 public class BatchResource {
 
+	private static Logger logger = LoggerFactory.getLogger(BatchResource.class);
+
     private final Sramp sramp = new Sramp();
+
 	/**
 	 * Constructor.
 	 */
@@ -94,6 +99,7 @@ public class BatchResource {
 
             return output;
         } catch (Exception e) {
+        	logger.error("Error consuming S-RAMP batch zip package.", e);
 			throw new SrampAtomException(e);
         } finally {
         	IOUtils.closeQuietly(is);

--- a/s-ramp-atom/src/main/java/org/overlord/sramp/atom/services/OntologyResource.java
+++ b/s-ramp-atom/src/main/java/org/overlord/sramp/atom/services/OntologyResource.java
@@ -40,6 +40,8 @@ import org.overlord.sramp.atom.mappers.RdfToOntologyMapper;
 import org.overlord.sramp.ontology.SrampOntology;
 import org.overlord.sramp.repository.PersistenceFactory;
 import org.overlord.sramp.repository.PersistenceManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.w3._1999._02._22_rdf_syntax_ns_.RDF;
 
 /**
@@ -56,6 +58,8 @@ import org.w3._1999._02._22_rdf_syntax_ns_.RDF;
  */
 @Path("/s-ramp")
 public class OntologyResource {
+
+	private static Logger logger = LoggerFactory.getLogger(OntologyResource.class);
 
 	private static OntologyToRdfMapper o2rdf = new OntologyToRdfMapper();
 	private static RdfToOntologyMapper rdf2o = new RdfToOntologyMapper();
@@ -100,6 +104,7 @@ public class OntologyResource {
 			entry.setAnyOtherJAXBObject(responseRDF);
 			return entry;
         } catch (Exception e) {
+        	logger.error("Error creating a new ontology.", e);
 			throw new SrampAtomException(e);
         }
     }
@@ -123,6 +128,7 @@ public class OntologyResource {
 			PersistenceManager persistenceManager = PersistenceFactory.newInstance();
 			persistenceManager.updateOntology(ontology);
         } catch (Exception e) {
+        	logger.error("Error updating an ontology with UUID: " + uuid, e);
 			throw new SrampAtomException(e);
         }
     }
@@ -156,6 +162,7 @@ public class OntologyResource {
 			entry.setAnyOtherJAXBObject(responseRDF);
 			return entry;
         } catch (Exception e) {
+        	logger.error("Error getting an ontology with UUID: " + uuid, e);
 			throw new SrampAtomException(e);
         }
     }
@@ -174,6 +181,7 @@ public class OntologyResource {
 			PersistenceManager persistenceManager = PersistenceFactory.newInstance();
 			persistenceManager.deleteOntology(uuid);
         } catch (Exception e) {
+        	logger.error("Error deleting an ontology with UUID: " + uuid, e);
 			throw new SrampAtomException(e);
         }
     }
@@ -213,6 +221,7 @@ public class OntologyResource {
 
 			return feed;
         } catch (Exception e) {
+        	logger.error("Error getting the list of ontologies.", e);
 			throw new SrampAtomException(e);
         }
 	}

--- a/s-ramp-atom/src/main/java/org/overlord/sramp/atom/services/QueryResource.java
+++ b/s-ramp-atom/src/main/java/org/overlord/sramp/atom/services/QueryResource.java
@@ -32,6 +32,8 @@ import org.jboss.resteasy.util.GenericType;
 import org.overlord.sramp.Sramp;
 import org.overlord.sramp.atom.MediaType;
 import org.overlord.sramp.atom.err.SrampAtomException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -39,6 +41,8 @@ import org.overlord.sramp.atom.err.SrampAtomException;
  */
 @Path("/s-ramp")
 public class QueryResource extends AbstractFeedResource {
+
+	private static Logger logger = LoggerFactory.getLogger(QueryResource.class);
 
 	private final Sramp sramp = new Sramp();
 
@@ -78,6 +82,7 @@ public class QueryResource extends AbstractFeedResource {
 			}
 			return query(query, startIndex, count, orderBy, asc, propNames, baseUrl);
 		} catch (Throwable e) {
+			logger.error("Error executing S-RAMP query: " + query, e);
 			throw new SrampAtomException(e);
 		}
 	}
@@ -91,9 +96,10 @@ public class QueryResource extends AbstractFeedResource {
 	@Consumes(MediaType.MULTIPART_FORM_DATA)
 	@Produces(MediaType.APPLICATION_ATOM_XML_FEED)
 	public Feed queryFromPost(@Context HttpServletRequest request, MultipartFormDataInput input) throws SrampAtomException {
+		String query = null;
 		try {
 			String baseUrl = sramp.getBaseUrl(request.getRequestURL().toString());
-			String query = input.getFormDataPart("query", new GenericType<String>() { });
+			query = input.getFormDataPart("query", new GenericType<String>() { });
 			Integer startPage = input.getFormDataPart("startPage", new GenericType<Integer>() { });
 			Integer startIndex = input.getFormDataPart("startIndex", new GenericType<Integer>() { });
 			Integer count = input.getFormDataPart("count", new GenericType<Integer>() { });
@@ -106,8 +112,10 @@ public class QueryResource extends AbstractFeedResource {
 			}
 			return query(query, startIndex, count, orderBy, asc, propNames, baseUrl);
 		} catch (SrampAtomException e) {
+			logger.error("Error executing S-RAMP query: " + query, e);
 			throw e;
 		} catch (Throwable e) {
+			logger.error("Error executing S-RAMP query: " + query, e);
 			throw new SrampAtomException(e);
 		}
 	}


### PR DESCRIPTION
Added error logging to all public methods on all Atom resources.  This
should ensure that all errors, even if they are properly propagated back
to the client, will be logged on the server.
