### PR TITLE
(sramp-77) Build S-RAMP distribution

### DIFF
--- a/s-ramp-client/src/main/java/org/overlord/sramp/client/shell/commands/brms/Dir2BrmsCommand.java
+++ b/s-ramp-client/src/main/java/org/overlord/sramp/client/shell/commands/brms/Dir2BrmsCommand.java
@@ -256,7 +256,7 @@ public class Dir2BrmsCommand extends AbstractShellCommand {
                         try {
                             is = jarFile.getInputStream(entry);
                             print("Uploading " + entryName + " -> " + urlStr );
-                            uploadToBrms(entryName, is, addAssetRequest);
+                            uploadToBrms(assetName, is, addAssetRequest);
                         } finally {
                             is.close();
                         }


### PR DESCRIPTION
Fixed a bug in the dir2brms - I was using the jar entry name rather than
the asset name when uploading to guvnor.
