### PR TITLE
(sramp-133) Interactive shell pluggable commands

### DIFF
--- a/s-ramp-governance/src/main/java/org/overlord/sramp/governance/shell/commands/Dir2BrmsCommand.java
+++ b/s-ramp-governance/src/main/java/org/overlord/sramp/governance/shell/commands/Dir2BrmsCommand.java
@@ -1,4 +1,4 @@
-package org.overlord.sramp.client.shell.commands.brms;
+package org.overlord.sramp.governance.shell.commands;
 
 import java.io.File;
 import java.io.FilenameFilter;

--- a/s-ramp-governance/src/main/java/org/overlord/sramp/governance/shell/commands/GovernanceShellCommandProvider.java
+++ b/s-ramp-governance/src/main/java/org/overlord/sramp/governance/shell/commands/GovernanceShellCommandProvider.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2012 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.overlord.sramp.governance.shell.commands;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.overlord.sramp.client.shell.ShellCommand;
+import org.overlord.sramp.client.shell.ShellCommandProvider;
+
+/**
+ *
+ * @author eric.wittmann@redhat.com
+ */
+public class GovernanceShellCommandProvider implements ShellCommandProvider {
+
+    /**
+     * Constructor.
+     */
+    public GovernanceShellCommandProvider() {
+    }
+
+    /**
+     * @see org.overlord.sramp.client.shell.ShellCommandProvider#getNamespace()
+     */
+    @Override
+    public String getNamespace() {
+        return "brms";
+    }
+
+    /**
+     * @see org.overlord.sramp.client.shell.ShellCommandProvider#provideCommands()
+     */
+    @Override
+    public Map<String, Class<? extends ShellCommand>> provideCommands() {
+        Map<String, Class<? extends ShellCommand>> rval = new HashMap<String, Class<? extends ShellCommand>>();
+        rval.put("dir2brms", Dir2BrmsCommand.class);
+        rval.put("pkg2sramp", Pkg2SrampCommand.class);
+        return rval;
+    }
+
+}

--- a/s-ramp-governance/src/main/java/org/overlord/sramp/governance/shell/commands/Pkg2SrampCommand.java
+++ b/s-ramp-governance/src/main/java/org/overlord/sramp/governance/shell/commands/Pkg2SrampCommand.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.overlord.sramp.client.shell.commands.brms;
+package org.overlord.sramp.governance.shell.commands;
 
 import java.io.InputStream;
 import java.net.HttpURLConnection;

--- a/s-ramp-governance/src/main/resources/META-INF/services/org.overlord.sramp.client.shell.ShellCommandProvider
+++ b/s-ramp-governance/src/main/resources/META-INF/services/org.overlord.sramp.client.shell.ShellCommandProvider
@@ -1,0 +1,1 @@
+org.overlord.sramp.governance.shell.commands.GovernanceShellCommandProvider


### PR DESCRIPTION
Officially made shell commands contributable, and moved BRMS related
commands out of the client module and into the governance module.
