### PR TITLE
(sramp-134) Support for user defined derivers (for user defined types)

### DIFF
--- a/s-ramp-atom-core/src/main/java/org/overlord/sramp/atom/SrampAtomUtils.java
+++ b/s-ramp-atom-core/src/main/java/org/overlord/sramp/atom/SrampAtomUtils.java
@@ -28,6 +28,7 @@ import org.jboss.resteasy.plugins.providers.atom.Entry;
 import org.jboss.resteasy.plugins.providers.atom.Link;
 import org.jboss.resteasy.plugins.providers.atom.Person;
 import org.overlord.sramp.ArtifactType;
+import org.overlord.sramp.SrampConstants;
 import org.s_ramp.xmlns._2010.s_ramp.Artifact;
 import org.s_ramp.xmlns._2010.s_ramp.BaseArtifactType;
 
@@ -131,17 +132,33 @@ public final class SrampAtomUtils {
 	}
 
 	/**
-	 * Figures out the S-RAMP artifact type for the given {@link Entry}.  There are a number of
-	 * ways we can do this.  We'll try them all:
-	 *
-	 * 1) check the 'self' link, parsing it for the type and model information
-	 * 2) check the Atom Category - there should be one for the artifact type
-	 * 3) unwrap the Entry's {@link Artifact} and get the artifactType value (xml attribute)
+     * Figures out the S-RAMP artifact type for the given {@link Entry}.
 	 *
 	 * @param entry
 	 */
 	public static ArtifactType getArtifactType(Entry entry) {
-		// Try the Category
+		ArtifactType type = getArtifactTypeFromEntry(entry);
+		if (type.isUserDefinedType()) {
+            boolean derived = "true".equals(entry.getExtensionAttributes().get(SrampConstants.SRAMP_DERIVED_QNAME));
+            String userType = (String) entry.getExtensionAttributes().get(SrampConstants.SRAMP_USER_TYPE_QNAME);
+            type.setUserDerivedType(derived);
+            type.setUserType(userType);
+		}
+        return type;
+	}
+
+    /**
+     * Figures out the S-RAMP artifact type for the given {@link Entry}.  There are a number of
+     * ways we can do this.  We'll try them all:
+     *
+     * 1) check the 'self' link, parsing it for the type and model information
+     * 2) check the Atom Category - there should be one for the artifact type
+     * 3) unwrap the Entry's {@link Artifact} and get the artifactType value (xml attribute)
+     *
+     * @param entry
+     */
+    protected static ArtifactType getArtifactTypeFromEntry(Entry entry) {
+        // Try the Category
 		List<Category> categories = entry.getCategories();
 		for (Category cat : categories) {
 			if ("x-s-ramp:2010:type".equals(cat.getScheme().toString())) {
@@ -172,7 +189,7 @@ public final class SrampAtomUtils {
 
 		// If all else fails!
 		return ArtifactType.valueOf("Document");
-	}
+    }
 
 	/**
 	 * Unwrap some other jaxb object from its Atom Entry wrapper.

--- a/s-ramp-atom-core/src/main/java/org/overlord/sramp/atom/visitors/ArtifactContentTypeVisitor.java
+++ b/s-ramp-atom-core/src/main/java/org/overlord/sramp/atom/visitors/ArtifactContentTypeVisitor.java
@@ -15,8 +15,6 @@
  */
 package org.overlord.sramp.atom.visitors;
 
-import javax.xml.namespace.QName;
-
 import org.overlord.sramp.SrampConstants;
 import org.overlord.sramp.atom.MediaType;
 import org.overlord.sramp.visitors.HierarchicalArtifactVisitorAdapter;
@@ -65,18 +63,19 @@ public class ArtifactContentTypeVisitor extends HierarchicalArtifactVisitorAdapt
 	protected void visitXmlDocument(XmlDocument artifact) {
 		setContentType(MediaType.APPLICATION_XML_TYPE);
 	}
-	
+
 	/**
 	 * org.overlord.sramp.visitors.HierarchicalArtifactVisitorAdapter#visitUserDefined(org.s_ramp.xmlns._2010.s_ramp.UserDefinedArtifactType)
 	 */
 	@Override
 	protected void visitUserDefined(UserDefinedArtifactType artifact) {
 	    //grab the content type from an any-attribute
-	    if ((artifact.getOtherAttributes().keySet().contains(new QName(SrampConstants.SRAMP_CONTENT_TYPE)))) {
-	        String contentTypeStr = artifact.getOtherAttributes().get(new QName(SrampConstants.SRAMP_CONTENT_TYPE));
-	        setContentType(MediaType.valueOf(contentTypeStr));
-	    } else {
-	        setContentType(MediaType.APPLICATION_OCTET_STREAM_TYPE);
+        setContentType(MediaType.APPLICATION_OCTET_STREAM_TYPE);
+	    if ((artifact.getOtherAttributes().keySet().contains(SrampConstants.SRAMP_CONTENT_TYPE_QNAME))) {
+	        String contentTypeStr = artifact.getOtherAttributes().get(SrampConstants.SRAMP_CONTENT_TYPE_QNAME);
+	        if (contentTypeStr != null) {
+	            setContentType(MediaType.valueOf(contentTypeStr));
+	        }
 	    }
 	}
 

--- a/s-ramp-atom-core/src/main/java/org/overlord/sramp/atom/visitors/ArtifactToSummaryAtomEntryVisitor.java
+++ b/s-ramp-atom-core/src/main/java/org/overlord/sramp/atom/visitors/ArtifactToSummaryAtomEntryVisitor.java
@@ -26,12 +26,14 @@ import org.jboss.resteasy.plugins.providers.atom.Entry;
 import org.jboss.resteasy.plugins.providers.atom.Link;
 import org.jboss.resteasy.plugins.providers.atom.Person;
 import org.overlord.sramp.ArtifactType;
+import org.overlord.sramp.SrampConstants;
 import org.overlord.sramp.atom.MediaType;
 import org.overlord.sramp.visitors.ArtifactVisitorAdapter;
 import org.overlord.sramp.visitors.ArtifactVisitorHelper;
 import org.s_ramp.xmlns._2010.s_ramp.Artifact;
 import org.s_ramp.xmlns._2010.s_ramp.BaseArtifactType;
 import org.s_ramp.xmlns._2010.s_ramp.Property;
+import org.s_ramp.xmlns._2010.s_ramp.UserDefinedArtifactType;
 
 /**
  * Visitor used to convert an artifact to an Atom entry.
@@ -94,7 +96,8 @@ public class ArtifactToSummaryAtomEntryVisitor extends ArtifactVisitorAdapter {
 	 * Creates the base Atom Entry, doing the stuff that's common to all types of artifacts.
 	 * @see org.overlord.sramp.visitors.ArtifactVisitorAdapter#visitBase(org.s_ramp.xmlns._2010.s_ramp.BaseArtifactType)
 	 */
-	@Override
+	@SuppressWarnings("unchecked")
+    @Override
 	protected void visitBase(BaseArtifactType artifact) {
 		try {
 			ArtifactType artifactType = ArtifactType.valueOf(artifact);
@@ -111,6 +114,7 @@ public class ArtifactToSummaryAtomEntryVisitor extends ArtifactVisitorAdapter {
 				entry.getAuthors().add(new Person(artifact.getCreatedBy()));
 			if (artifact.getDescription() != null)
 				entry.setSummary(artifact.getDescription());
+			entry.getExtensionAttributes().put(SrampConstants.SRAMP_DERIVED_QNAME, String.valueOf(artifactType.isDerived()));
 
 			String atomLink = baseUrl + "/s-ramp/"
 					+ artifactType.getModel() + "/"
@@ -146,13 +150,14 @@ public class ArtifactToSummaryAtomEntryVisitor extends ArtifactVisitorAdapter {
 			linkToEdit.setHref(new URI(atomLink));
 			entry.getLinks().add(linkToEdit);
 
-			//category
+			// Type category
 			Category typeCat = new Category();
 			typeCat.setTerm(artifactType.getType());
 			typeCat.setLabel(artifactType.getLabel());
 			typeCat.setScheme(new URI("x-s-ramp:2010:type"));
 			entry.getCategories().add(typeCat);
 
+			// Model category
 			Category modelCat = new Category();
 			modelCat.setTerm(artifactType.getModel());
 			modelCat.setLabel(artifactType.getLabel());
@@ -171,6 +176,20 @@ public class ArtifactToSummaryAtomEntryVisitor extends ArtifactVisitorAdapter {
 		} catch (Exception e) {
 			this.failure = e;
 		}
+	}
+
+	/**
+	 * @see org.overlord.sramp.visitors.ArtifactVisitorAdapter#visit(org.s_ramp.xmlns._2010.s_ramp.UserDefinedArtifactType)
+	 */
+	@SuppressWarnings("unchecked")
+    @Override
+	public void visit(UserDefinedArtifactType artifact) {
+	    super.visit(artifact);
+
+	    if (this.atomEntry != null) {
+	        String userType = artifact.getUserType();
+	        this.atomEntry.getExtensionAttributes().put(SrampConstants.SRAMP_DERIVED_QNAME, userType);
+	    }
 	}
 
 	/**

--- a/s-ramp-atom/src/main/java/org/overlord/sramp/atom/services/AbstractFeedResource.java
+++ b/s-ramp-atom/src/main/java/org/overlord/sramp/atom/services/AbstractFeedResource.java
@@ -27,6 +27,7 @@ import org.jboss.resteasy.plugins.providers.atom.Entry;
 import org.jboss.resteasy.plugins.providers.atom.Feed;
 import org.jboss.resteasy.plugins.providers.atom.Link;
 import org.jboss.resteasy.plugins.providers.atom.Person;
+import org.overlord.sramp.SrampConstants;
 import org.overlord.sramp.atom.MediaType;
 import org.overlord.sramp.atom.err.SrampAtomException;
 import org.overlord.sramp.atom.visitors.ArtifactToSummaryAtomEntryVisitor;
@@ -113,8 +114,10 @@ public abstract class AbstractFeedResource extends AbstractResource {
 	 * @return an Atom {@link Feed}
 	 * @throws Exception
 	 */
-	private Feed createFeed(ArtifactSet artifactSet, int fromRow, int toRow, Set<String> propNames, String baseUrl) throws Exception {
+	@SuppressWarnings("unchecked")
+    private Feed createFeed(ArtifactSet artifactSet, int fromRow, int toRow, Set<String> propNames, String baseUrl) throws Exception {
 		Feed feed = new Feed();
+		feed.getExtensionAttributes().put(SrampConstants.SRAMP_PROVIDER_QNAME, "JBoss Overlord");
 		feed.setId(new URI(UUID.randomUUID().toString()));
 		feed.setTitle("S-RAMP Feed");
 		feed.setSubtitle("Ad Hoc query feed");

--- a/s-ramp-atom/src/main/java/org/overlord/sramp/atom/services/ArtifactResource.java
+++ b/s-ramp-atom/src/main/java/org/overlord/sramp/atom/services/ArtifactResource.java
@@ -35,7 +35,6 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.StreamingOutput;
-import javax.xml.namespace.QName;
 
 import org.apache.commons.io.IOUtils;
 import org.jboss.resteasy.plugins.providers.atom.Entry;
@@ -357,8 +356,7 @@ public class ArtifactResource extends AbstractResource {
 			        .ok(output, artifactType.getMimeType())
 			        .header("Content-Disposition", "attachment; filename=" + baseArtifact.getName())
 			        .header("Content-Length",
-			                baseArtifact.getOtherAttributes().get(
-			                        new QName(SrampConstants.SRAMP_CONTENT_SIZE)))
+			                baseArtifact.getOtherAttributes().get(SrampConstants.SRAMP_CONTENT_SIZE_QNAME))
 			        .header("Last-Modified", lastModifiedDate).build();
 		} catch (Throwable e) {
 			logError(logger, "Error getting artifact content for: " + uuid, e);

--- a/s-ramp-atom/src/main/java/org/overlord/sramp/atom/services/brms/BrmsResource.java
+++ b/s-ramp-atom/src/main/java/org/overlord/sramp/atom/services/brms/BrmsResource.java
@@ -33,7 +33,6 @@ import javax.ws.rs.core.StreamingOutput;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBElement;
 import javax.xml.bind.Unmarshaller;
-import javax.xml.namespace.QName;
 import javax.xml.transform.stream.StreamSource;
 
 import org.apache.commons.io.IOUtils;
@@ -156,8 +155,8 @@ public class BrmsResource {
     @GET
     @Path("rest/packages/{pkgName}/assets/{assetName}")
     @Produces({MediaType.APPLICATION_ATOM_XML_ENTRY, MediaType.APPLICATION_ATOM_XML})
-    public Entry getRestXMLAsset(@PathParam("pkgName") String pkgName, 
-                                    @PathParam("assetName") String assetName) 
+    public Entry getRestXMLAsset(@PathParam("pkgName") String pkgName,
+                                    @PathParam("assetName") String assetName)
        throws SrampAtomException {
 
         try {
@@ -211,7 +210,7 @@ public class BrmsResource {
      * Returns the content of a Brms/Drools Package in the s-ramp repository. Note that
      * if multiple droolsPackage with the name are found it simply takes the first one.
      * This is probably a situation you want to avoid.
-     * 
+     *
      * @param pkgName - the name of the Brms Package
      * @throws SrampAtomException
      * http://localhost:8880/s-ramp-atom/brms/org.drools.guvnor.Guvnor/package/srampPackage/S-RAMP-0.0.3.0
@@ -231,7 +230,7 @@ public class BrmsResource {
      * Returns the content of a Brms/Drools Package in the s-ramp repository. Note that
      * if multiple droolsPackage with the name are found it simply takes the first one.
      * This is probably a situation you want to avoid.
-     * 
+     *
      * @param pkgName - the name of the Brms Package
      * @throws SrampAtomException
      */
@@ -263,7 +262,7 @@ public class BrmsResource {
                 String lastModifiedDate = simpleDateFormat.format(baseArtifact.getLastModifiedTimestamp().toGregorianCalendar().getTime());
                 return Response.ok(output, "application/octet-stream")
                     .header("Content-Disposition", "attachment; filename=" + baseArtifact.getName())
-                    .header("Content-Length", baseArtifact.getOtherAttributes().get(new QName(SrampConstants.SRAMP_CONTENT_SIZE)))
+                    .header("Content-Length", baseArtifact.getOtherAttributes().get(SrampConstants.SRAMP_CONTENT_SIZE_QNAME))
                     .header("Last-Modified", lastModifiedDate)
                     .build();
             } else {
@@ -273,10 +272,10 @@ public class BrmsResource {
             throw new SrampAtomException(e);
         }
     }
-    
+
     @GET
     @Path("org.drools.guvnor.Guvnor/package/{pkgName}/{version}/{fileName}")
-    public Response getDroolsFile(@PathParam("pkgName")   String pkgName, 
+    public Response getDroolsFile(@PathParam("pkgName")   String pkgName,
                              @PathParam("version")  String version,
                              @PathParam("fileName") String fileName) throws SrampAtomException {
         String assetName = fileName;
@@ -289,7 +288,7 @@ public class BrmsResource {
      * Returns the content of a Brms/Drools Package in the s-ramp repository. Note that
      * if multiple droolsPackage with the name are found it simply takes the first one.
      * This is probably a situation you want to avoid.
-     * 
+     *
      * @param pkgName - the name of the Brms Package
      * @param assetName - the name of the Brms Asset
      * @throws SrampAtomException
@@ -300,7 +299,7 @@ public class BrmsResource {
     @Produces({MediaType.APPLICATION_ATOM_XML, "application/octet-stream"})
     @Path("rest/packages/{pkgName}/assets/{assetName}/binary")
     public Response getRestAsset(@HeaderParam("Accept") String accept,
-                             @PathParam("pkgName")   String pkgName, 
+                             @PathParam("pkgName")   String pkgName,
                              @PathParam("assetName") String assetName
                              ) throws SrampAtomException {
         try {
@@ -337,13 +336,13 @@ public class BrmsResource {
                 String lastModifiedDate = simpleDateFormat.format(baseArtifact.getLastModifiedTimestamp().toGregorianCalendar().getTime());
                 if (accept!=null && (accept.contains(MediaType.APPLICATION_ATOM_XML) || accept.contains(MediaType.APPLICATION_XML) )) {
                     return Response.ok(output, MediaType.APPLICATION_XML)
-                    .header("Content-Length", baseArtifact.getOtherAttributes().get(new QName(SrampConstants.SRAMP_CONTENT_SIZE)))
+                    .header("Content-Length", baseArtifact.getOtherAttributes().get(SrampConstants.SRAMP_CONTENT_SIZE_QNAME))
                     .header("Last-Modified", lastModifiedDate)
                     .build();
                 } else {
                      return Response.ok(output, "application/octet-stream")
                         .header("Content-Disposition", "attachment; filename=" + baseArtifact.getName())
-                        .header("Content-Length", baseArtifact.getOtherAttributes().get(new QName(SrampConstants.SRAMP_CONTENT_SIZE)))
+                        .header("Content-Length", baseArtifact.getOtherAttributes().get(SrampConstants.SRAMP_CONTENT_SIZE_QNAME))
                         .header("Last-Modified", lastModifiedDate)
                         .build();
                 }
@@ -355,10 +354,10 @@ public class BrmsResource {
             throw new SrampAtomException(e);
         }
     }
-    
+
     @GET
     @Path("rest/packages/{pkgName}/assets/{assetName}/source")
-    public Response getRestSourceAsset(@PathParam("pkgName")   String pkgName, 
+    public Response getRestSourceAsset(@PathParam("pkgName")   String pkgName,
                              @PathParam("assetName") String assetName) throws SrampAtomException {
         return getRestAsset(MediaType.APPLICATION_XML, pkgName, assetName);
     }

--- a/s-ramp-atom/src/test/java/org/overlord/sramp/atom/services/ArtifactResourceTest.java
+++ b/s-ramp-atom/src/test/java/org/overlord/sramp/atom/services/ArtifactResourceTest.java
@@ -27,8 +27,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.xml.namespace.QName;
-
 import org.apache.commons.io.IOUtils;
 import org.jboss.resteasy.client.ClientResponse;
 import org.jboss.resteasy.plugins.providers.atom.Entry;
@@ -179,8 +177,8 @@ public class ArtifactResourceTest extends AbstractResourceTest {
             UserDefinedArtifactType doc = (UserDefinedArtifactType) arty;
             Assert.assertEquals(artifactFileName, doc.getName());
             Assert.assertEquals("BrmsPkgDocument", doc.getUserType());
-            Assert.assertEquals(Long.valueOf(17043), Long.valueOf(doc.getOtherAttributes().get(new QName(SrampConstants.SRAMP_CONTENT_SIZE))));
-            Assert.assertEquals("application/octet-stream", doc.getOtherAttributes().get(new QName(SrampConstants.SRAMP_CONTENT_TYPE)));
+            Assert.assertEquals(Long.valueOf(17043), Long.valueOf(doc.getOtherAttributes().get(SrampConstants.SRAMP_CONTENT_SIZE_QNAME)));
+            Assert.assertEquals("application/octet-stream", doc.getOtherAttributes().get(SrampConstants.SRAMP_CONTENT_TYPE_QNAME));
             uuid = doc.getUuid();
         } finally {
             IOUtils.closeQuietly(contentStream);
@@ -195,9 +193,9 @@ public class ArtifactResourceTest extends AbstractResourceTest {
         Assert.assertTrue(arty instanceof UserDefinedArtifactType);
         UserDefinedArtifactType doc = (UserDefinedArtifactType) arty;
         Assert.assertEquals(artifactFileName, doc.getName());
-        Assert.assertEquals(Long.valueOf(17043), Long.valueOf(doc.getOtherAttributes().get(new QName(SrampConstants.SRAMP_CONTENT_SIZE))));
+        Assert.assertEquals(Long.valueOf(17043), Long.valueOf(doc.getOtherAttributes().get(SrampConstants.SRAMP_CONTENT_SIZE_QNAME)));
         Assert.assertEquals("defaultPackage.pkg", doc.getName());
-        Assert.assertEquals("application/octet-stream", doc.getOtherAttributes().get(new QName(SrampConstants.SRAMP_CONTENT_TYPE)));
+        Assert.assertEquals("application/octet-stream", doc.getOtherAttributes().get(SrampConstants.SRAMP_CONTENT_TYPE_QNAME));
     }
 
     /**
@@ -224,8 +222,8 @@ public class ArtifactResourceTest extends AbstractResourceTest {
             UserDefinedArtifactType doc = (UserDefinedArtifactType) arty;
             Assert.assertEquals(artifactFileName, doc.getName());
             Assert.assertEquals("JpgDocument", doc.getUserType());
-            Assert.assertEquals(Long.valueOf(2966447), Long.valueOf(doc.getOtherAttributes().get(new QName(SrampConstants.SRAMP_CONTENT_SIZE))));
-            Assert.assertEquals("application/octet-stream", doc.getOtherAttributes().get(new QName(SrampConstants.SRAMP_CONTENT_TYPE)));
+            Assert.assertEquals(Long.valueOf(2966447), Long.valueOf(doc.getOtherAttributes().get(SrampConstants.SRAMP_CONTENT_SIZE_QNAME)));
+            Assert.assertEquals("application/octet-stream", doc.getOtherAttributes().get(SrampConstants.SRAMP_CONTENT_TYPE_QNAME));
             uuid = doc.getUuid();
         } finally {
             IOUtils.closeQuietly(contentStream);
@@ -240,9 +238,9 @@ public class ArtifactResourceTest extends AbstractResourceTest {
         Assert.assertTrue(arty instanceof UserDefinedArtifactType);
         UserDefinedArtifactType doc = (UserDefinedArtifactType) arty;
         Assert.assertEquals(artifactFileName, doc.getName());
-        Assert.assertEquals(Long.valueOf(2966447), Long.valueOf(doc.getOtherAttributes().get(new QName(SrampConstants.SRAMP_CONTENT_SIZE))));
+        Assert.assertEquals(Long.valueOf(2966447), Long.valueOf(doc.getOtherAttributes().get(SrampConstants.SRAMP_CONTENT_SIZE_QNAME)));
         Assert.assertEquals("photo.jpg", doc.getName());
-        Assert.assertEquals("application/octet-stream", doc.getOtherAttributes().get(new QName(SrampConstants.SRAMP_CONTENT_TYPE)));
+        Assert.assertEquals("application/octet-stream", doc.getOtherAttributes().get(SrampConstants.SRAMP_CONTENT_TYPE_QNAME));
 
         //Obtain the content for visual inspection
         ClientRequest request2 = new ClientRequest(generateURL("/s-ramp/user/JpgDocument/" + uuid + "/media"));
@@ -284,8 +282,8 @@ public class ArtifactResourceTest extends AbstractResourceTest {
             UserDefinedArtifactType doc = (UserDefinedArtifactType) arty;
             Assert.assertEquals(artifactFileName, doc.getName());
             Assert.assertEquals("BpmnDocument", doc.getUserType());
-            Assert.assertEquals(Long.valueOf(12482), Long.valueOf(doc.getOtherAttributes().get(new QName(SrampConstants.SRAMP_CONTENT_SIZE))));
-            Assert.assertEquals("application/xml", doc.getOtherAttributes().get(new QName(SrampConstants.SRAMP_CONTENT_TYPE)));
+            Assert.assertEquals(Long.valueOf(12482), Long.valueOf(doc.getOtherAttributes().get(SrampConstants.SRAMP_CONTENT_SIZE_QNAME)));
+            Assert.assertEquals("application/xml", doc.getOtherAttributes().get(SrampConstants.SRAMP_CONTENT_TYPE_QNAME));
             uuid = doc.getUuid();
         } finally {
             IOUtils.closeQuietly(contentStream);
@@ -300,9 +298,9 @@ public class ArtifactResourceTest extends AbstractResourceTest {
         Assert.assertTrue(arty instanceof UserDefinedArtifactType);
         UserDefinedArtifactType doc = (UserDefinedArtifactType) arty;
         Assert.assertEquals(artifactFileName, doc.getName());
-        Assert.assertEquals(Long.valueOf(12482), Long.valueOf(doc.getOtherAttributes().get(new QName(SrampConstants.SRAMP_CONTENT_SIZE))));
+        Assert.assertEquals(Long.valueOf(12482), Long.valueOf(doc.getOtherAttributes().get(SrampConstants.SRAMP_CONTENT_SIZE_QNAME)));
         Assert.assertEquals("Evaluation.bpmn", doc.getName());
-        Assert.assertEquals("application/xml", doc.getOtherAttributes().get(new QName(SrampConstants.SRAMP_CONTENT_TYPE)));
+        Assert.assertEquals("application/xml", doc.getOtherAttributes().get(SrampConstants.SRAMP_CONTENT_TYPE_QNAME));
 
         ClientResponse<String> content = request.get(String.class);
         System.out.println("Content=" + content.getEntity());

--- a/s-ramp-atom/src/test/java/org/overlord/sramp/atom/services/QueryResourceTest.java
+++ b/s-ramp-atom/src/test/java/org/overlord/sramp/atom/services/QueryResourceTest.java
@@ -24,8 +24,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
-import javax.xml.namespace.QName;
-
 import org.apache.commons.io.IOUtils;
 import org.jboss.resteasy.client.ClientResponse;
 import org.jboss.resteasy.plugins.providers.atom.Entry;
@@ -220,8 +218,8 @@ public class QueryResourceTest extends AbstractResourceTest {
 			UserDefinedArtifactType doc = (UserDefinedArtifactType) arty;
 			Assert.assertEquals(fname, doc.getName());
 			Assert.assertEquals("JpgDocument", doc.getUserType());
-			Assert.assertEquals(Long.valueOf(2966447), Long.valueOf(doc.getOtherAttributes().get(new QName(SrampConstants.SRAMP_CONTENT_SIZE))));
-			Assert.assertEquals("application/octet-stream", doc.getOtherAttributes().get(new QName(SrampConstants.SRAMP_CONTENT_TYPE)));
+			Assert.assertEquals(Long.valueOf(2966447), Long.valueOf(doc.getOtherAttributes().get(SrampConstants.SRAMP_CONTENT_SIZE_QNAME)));
+			Assert.assertEquals("application/octet-stream", doc.getOtherAttributes().get(SrampConstants.SRAMP_CONTENT_TYPE_QNAME));
 		} finally {
 			IOUtils.closeQuietly(contentStream);
 		}

--- a/s-ramp-client/src/main/java/org/overlord/sramp/client/query/ArtifactSummary.java
+++ b/s-ramp-client/src/main/java/org/overlord/sramp/client/query/ArtifactSummary.java
@@ -88,5 +88,17 @@ public class ArtifactSummary {
 		return entry.getSummary();
 	}
 
+	/**
+	 * @return true if the artifact is a user-defined type
+	 */
+	public boolean isUserDefinedType() {
+	    return getType().isUserDefinedType();
+	}
 
+	/**
+	 * @return true if the artifact is a derived type
+	 */
+	public boolean isDerived() {
+        return getType().isDerived();
+	}
 }

--- a/s-ramp-client/src/main/java/org/overlord/sramp/client/shell/commands/core/QueryCommand.java
+++ b/s-ramp-client/src/main/java/org/overlord/sramp/client/shell/commands/core/QueryCommand.java
@@ -85,7 +85,11 @@ public class QueryCommand extends AbstractShellCommand {
 		print("  ---                    ---- ----");
 		for (ArtifactSummary summary : rset) {
 			ArtifactType type = summary.getType();
-			print("  %1$3d %2$23s %3$-40s", entryIndex++, type.getArtifactType().getType().toString(),
+			String displayType = type.getArtifactType().getType().toString();
+			if (type.isUserDefinedType() && type.getUserType() != null) {
+			    displayType = type.getUserType();
+			}
+            print("  %1$3d %2$23s %3$-40s", entryIndex++, displayType,
 					summary.getName());
 		}
 		getContext().setVariable(new QName("s-ramp", "feed"), rset);

--- a/s-ramp-client/src/main/java/org/overlord/sramp/client/shell/commands/core/UploadArtifactCommand.java
+++ b/s-ramp-client/src/main/java/org/overlord/sramp/client/shell/commands/core/UploadArtifactCommand.java
@@ -115,15 +115,15 @@ public class UploadArtifactCommand extends AbstractShellCommand {
 		ArtifactType type = null;
 		String extension = FilenameUtils.getExtension(file.getName());
 		if ("wsdl".equals(extension)) {
-			type = ArtifactType.WsdlDocument;
+			type = ArtifactType.WsdlDocument();
 		} else if ("xsd".equals(extension)) {
-			type = ArtifactType.XsdDocument;
+			type = ArtifactType.XsdDocument();
 		} else if ("wspolicy".equals(extension)) {
-			type = ArtifactType.PolicyDocument;
+			type = ArtifactType.PolicyDocument();
 		} else if ("xml".equals(extension)) {
-			type = ArtifactType.XmlDocument;
+			type = ArtifactType.XmlDocument();
 		} else {
-			type = ArtifactType.valueOf("Document");
+			type = ArtifactType.Document();
 		}
 		return type;
 	}

--- a/s-ramp-client/src/main/java/org/overlord/sramp/client/shell/util/PrintArtifactMetaDataVisitor.java
+++ b/s-ramp-client/src/main/java/org/overlord/sramp/client/shell/util/PrintArtifactMetaDataVisitor.java
@@ -27,7 +27,6 @@ import org.s_ramp.xmlns._2010.s_ramp.NamedWsdlDerivedArtifactType;
 import org.s_ramp.xmlns._2010.s_ramp.Property;
 import org.s_ramp.xmlns._2010.s_ramp.Relationship;
 import org.s_ramp.xmlns._2010.s_ramp.Target;
-import org.s_ramp.xmlns._2010.s_ramp.UserDefinedArtifactType;
 import org.s_ramp.xmlns._2010.s_ramp.XmlDocument;
 
 /**
@@ -50,11 +49,15 @@ public class PrintArtifactMetaDataVisitor extends HierarchicalArtifactVisitorAda
 	protected void visitBase(BaseArtifactType artifact) {
 		ArtifactType artifactType = ArtifactType.valueOf(artifact);
 		System.out.println("  -- Core S-RAMP Info --");
-		printProperty("Type", artifactType.getArtifactType().getType());
+        if (artifactType.isUserDefinedType())
+            printProperty("Type", artifactType.getUserType());
+        else
+            printProperty("Type", artifactType.getArtifactType().getType());
 		printProperty("Model", artifactType.getArtifactType().getModel());
 		printProperty("UUID", artifact.getUuid());
 		printProperty("Name", artifact.getName());
 		printProperty("Version", artifact.getVersion());
+		printProperty("Derived", String.valueOf(artifactType.isDerived()));
 		printProperty("Created By", artifact.getCreatedBy());
 		if (artifact.getCreatedTimestamp() != null)
 			printProperty("Created On", artifact.getCreatedTimestamp().toXMLFormat());
@@ -122,15 +125,6 @@ public class PrintArtifactMetaDataVisitor extends HierarchicalArtifactVisitorAda
 	protected void visitNamedWsdlDerived(NamedWsdlDerivedArtifactType artifact) {
 		System.out.println("  -- Named WSDL Info --");
 		printProperty("NCName", artifact.getNCName());
-	}
-
-	/**
-	 * @see org.overlord.sramp.visitors.HierarchicalArtifactVisitorAdapter#visitUserDefined(org.s_ramp.xmlns._2010.s_ramp.UserDefinedArtifactType)
-	 */
-	@Override
-	protected void visitUserDefined(UserDefinedArtifactType artifact) {
-		System.out.println("  -- User Defined Type Info --");
-		printProperty("User Type", artifact.getUserType());
 	}
 
 	/**

--- a/s-ramp-client/src/test/java/org/overlord/sramp/client/SrampAtomApiClientTest.java
+++ b/s-ramp-client/src/test/java/org/overlord/sramp/client/SrampAtomApiClientTest.java
@@ -82,7 +82,7 @@ public class SrampAtomApiClientTest extends BaseResourceTest {
 		InputStream is = this.getClass().getResourceAsStream("/sample-files/xsd/" + artifactFileName);
 		try {
 			SrampAtomApiClient client = new SrampAtomApiClient(generateURL("/s-ramp"));
-			BaseArtifactType artifact = client.uploadArtifact(ArtifactType.XsdDocument, is, artifactFileName);
+			BaseArtifactType artifact = client.uploadArtifact(ArtifactType.XsdDocument(), is, artifactFileName);
 			Assert.assertNotNull(artifact);
 			Assert.assertEquals(artifactFileName, artifact.getName());
 		} finally {
@@ -123,7 +123,7 @@ public class SrampAtomApiClientTest extends BaseResourceTest {
 		String artifactFileName = "PO.xsd";
 		InputStream is = this.getClass().getResourceAsStream("/sample-files/xsd/" + artifactFileName);
 		try {
-			BaseArtifactType artifact = client.uploadArtifact(ArtifactType.XsdDocument, is, artifactFileName);
+			BaseArtifactType artifact = client.uploadArtifact(ArtifactType.XsdDocument(), is, artifactFileName);
 			Assert.assertNotNull(artifact);
 			Assert.assertEquals(artifactFileName, artifact.getName());
 			uuid = artifact.getUuid();
@@ -132,7 +132,7 @@ public class SrampAtomApiClientTest extends BaseResourceTest {
 		}
 
 		// Now get the content.
-		InputStream content = client.getArtifactContent(ArtifactType.XsdDocument, uuid.toString());
+		InputStream content = client.getArtifactContent(ArtifactType.XsdDocument(), uuid.toString());
 		try {
 			Assert.assertNotNull(content);
 			BufferedReader reader = new BufferedReader(new InputStreamReader(content));
@@ -158,7 +158,7 @@ public class SrampAtomApiClientTest extends BaseResourceTest {
 		String artifactFileName = "PO.xsd";
 		InputStream is = this.getClass().getResourceAsStream("/sample-files/xsd/" + artifactFileName);
 		try {
-			BaseArtifactType artifact = client.uploadArtifact(ArtifactType.XsdDocument, is, artifactFileName);
+			BaseArtifactType artifact = client.uploadArtifact(ArtifactType.XsdDocument(), is, artifactFileName);
 			Assert.assertNotNull(artifact);
 			Assert.assertEquals(artifactFileName, artifact.getName());
 			uuid = artifact.getUuid();
@@ -172,7 +172,7 @@ public class SrampAtomApiClientTest extends BaseResourceTest {
 		client.updateArtifactMetaData(xsdDoc);
 
 		// Now verify
-		BaseArtifactType artifact = client.getArtifactMetaData(ArtifactType.XsdDocument, uuid.toString());
+		BaseArtifactType artifact = client.getArtifactMetaData(ArtifactType.XsdDocument(), uuid.toString());
 		Assert.assertEquals("** DESCRIPTION UPDATED **", artifact.getDescription());
 	}
 
@@ -189,7 +189,7 @@ public class SrampAtomApiClientTest extends BaseResourceTest {
 		String artifactFileName = "PO.xsd";
 		InputStream is = this.getClass().getResourceAsStream("/sample-files/xsd/" + artifactFileName);
 		try {
-			BaseArtifactType artifact = client.uploadArtifact(ArtifactType.XsdDocument, is, artifactFileName);
+			BaseArtifactType artifact = client.uploadArtifact(ArtifactType.XsdDocument(), is, artifactFileName);
 			Assert.assertNotNull(artifact);
 			Assert.assertEquals(artifactFileName, artifact.getName());
 			uuid = artifact.getUuid();
@@ -207,7 +207,7 @@ public class SrampAtomApiClientTest extends BaseResourceTest {
 		}
 
 		// Now verify
-		BaseArtifactType artifact = client.getArtifactMetaData(ArtifactType.XsdDocument, uuid.toString());
+		BaseArtifactType artifact = client.getArtifactMetaData(ArtifactType.XsdDocument(), uuid.toString());
 		xsdDoc = (XsdDocument) artifact;
 		Assert.assertEquals(new Long(2583), xsdDoc.getContentSize());
 	}
@@ -224,7 +224,7 @@ public class SrampAtomApiClientTest extends BaseResourceTest {
 		String artifactFileName = "PO.xsd";
 		InputStream is = this.getClass().getResourceAsStream("/sample-files/xsd/" + artifactFileName);
 		try {
-			BaseArtifactType artifact = client.uploadArtifact(ArtifactType.XsdDocument, is, artifactFileName);
+			BaseArtifactType artifact = client.uploadArtifact(ArtifactType.XsdDocument(), is, artifactFileName);
 			Assert.assertNotNull(artifact);
 			Assert.assertEquals(artifactFileName, artifact.getName());
 			uuid = artifact.getUuid();

--- a/s-ramp-core/src/main/java/org/overlord/sramp/ArtifactType.java
+++ b/s-ramp-core/src/main/java/org/overlord/sramp/ArtifactType.java
@@ -19,8 +19,6 @@ import java.lang.reflect.Method;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import javax.xml.namespace.QName;
-
 import org.s_ramp.xmlns._2010.s_ramp.Artifact;
 import org.s_ramp.xmlns._2010.s_ramp.BaseArtifactEnum;
 import org.s_ramp.xmlns._2010.s_ramp.BaseArtifactType;
@@ -28,23 +26,59 @@ import org.s_ramp.xmlns._2010.s_ramp.DocumentArtifactType;
 import org.s_ramp.xmlns._2010.s_ramp.UserDefinedArtifactType;
 
 /**
- * An enum representing all of the Artifact Types defined by S-RAMP.
+ * A class representing all of the Artifact Types defined by S-RAMP.
  *
  * @author eric.wittmann@redhat.com
  */
 public class ArtifactType {
 
-    public static final ArtifactType Document = new ArtifactType(ArtifactTypeEnum.Document, "application/octet-stream");
-    public static final ArtifactType XmlDocument = new ArtifactType(ArtifactTypeEnum.XmlDocument, "application/xml");
-    public static final ArtifactType XsdDocument = new ArtifactType(ArtifactTypeEnum.XsdDocument, "application/xml");
-    public static final ArtifactType WsdlDocument = new ArtifactType(ArtifactTypeEnum.WsdlDocument, "application/xml");
-    public static final ArtifactType PolicyDocument = new ArtifactType(ArtifactTypeEnum.PolicyDocument, "application/xml");
+    public static final ArtifactType Document() {
+        return new ArtifactType(ArtifactTypeEnum.Document, "application/octet-stream");
+    }
+    public static final ArtifactType XmlDocument() {
+        return new ArtifactType(ArtifactTypeEnum.XmlDocument, "application/xml");
+    }
+    public static final ArtifactType XsdDocument() {
+        return new ArtifactType(ArtifactTypeEnum.XsdDocument, "application/xml");
+    }
+    public static final ArtifactType WsdlDocument() {
+        return new ArtifactType(ArtifactTypeEnum.WsdlDocument, "application/xml");
+    }
+    public static final ArtifactType PolicyDocument() {
+        return new ArtifactType(ArtifactTypeEnum.PolicyDocument, "application/xml");
+    }
+    public static final ArtifactType UserDefined(String userType, boolean derived) {
+        ArtifactType at = new ArtifactType(ArtifactTypeEnum.UserDefinedArtifactType, null);
+        at.setUserType(userType);
+        at.setUserDerivedType(derived);
+        return at;
+    }
 
 	private ArtifactTypeEnum artifactType;
 	private String mimeType;
 	/** for a UserDefined Type, the type should be stored here */
 	private String userType;
+	private boolean userDerivedType;
 	private static Map<String, ModelMime> userDefinedArtifactTypes;
+	static {
+	    userDefinedArtifactTypes = new ConcurrentHashMap<String, ModelMime>();
+        //TODO use SRAMP documents to store SRAMP internal information? We would put this one in here as
+        // an hard coded UserDefinedArtifactType (UserDefined by us)
+        userDefinedArtifactTypes.put("sramp",      new ModelMime("SRAMPDocument",   "application/xml"));
+        //TODO read this from the repo instead (store as an Artifact, can we do TextDocument?)
+        userDefinedArtifactTypes.put("pkg",        new ModelMime("BrmsPkgDocument", "application/octet-stream"));
+        userDefinedArtifactTypes.put("package",    new ModelMime("BrmsPkgDocument", "application/octet-stream"));
+        userDefinedArtifactTypes.put("bpmn",       new ModelMime("BpmnDocument",    "application/xml"));
+        userDefinedArtifactTypes.put("bpmn2",      new ModelMime("BpmnDocument",    "application/xml"));
+        userDefinedArtifactTypes.put("txt",        new ModelMime("TextDocument",    "text/plain"));
+        userDefinedArtifactTypes.put("properties", new ModelMime("TextDocument",    "text/plain"));
+        userDefinedArtifactTypes.put("css",        new ModelMime("CssDocument",     "text/css"));
+        userDefinedArtifactTypes.put("html",       new ModelMime("HtmlDocument",    "text/html"));
+        userDefinedArtifactTypes.put("ftl",        new ModelMime("FtlDocument",     "text/html"));
+        userDefinedArtifactTypes.put("wid",        new ModelMime("TextDocument",    "text/plain"));
+        userDefinedArtifactTypes.put("gif",        new ModelMime("ImageDocument",   "application/octet-stream"));
+        userDefinedArtifactTypes.put("png",        new ModelMime("ImageDocument",   "application/octet-stream"));
+	}
 
 	/**
 	 * Constructor.
@@ -52,7 +86,6 @@ public class ArtifactType {
 	 * @param mimeType
 	 */
 	private ArtifactType(ArtifactTypeEnum artifactType, String mimeType) {
-	    init();
 		setArtifactType(artifactType);
 		// Might need something more interesting than this in the future.
 		if (mimeType == null) {
@@ -63,28 +96,6 @@ public class ArtifactType {
 			}
 		}
 		setMimeType(mimeType);
-	}
-
-	private void init() {
-	    if (userDefinedArtifactTypes==null) {
-    	    userDefinedArtifactTypes = new ConcurrentHashMap<String, ModelMime>();
-    	    //TODO use SRAMP documents to store SRAMP internal information? We would put this one in here as
-    	    // an hard coded UserDefinedArtifactType (UserDefined by us)
-    	    userDefinedArtifactTypes.put("sramp",      new ModelMime("SRAMPDocument",   "application/xml"));
-    	    //TODO read this from the repo instead (store as an Artifact, can we do TextDocument?)
-    	    userDefinedArtifactTypes.put("pkg",        new ModelMime("BrmsPkgDocument", "application/octet-stream"));
-    	    userDefinedArtifactTypes.put("package",    new ModelMime("BrmsPkgDocument", "application/octet-stream"));
-    	    userDefinedArtifactTypes.put("bpmn",       new ModelMime("BpmnDocument",    "application/xml"));
-    	    userDefinedArtifactTypes.put("bpmn2",      new ModelMime("BpmnDocument",    "application/xml"));
-    	    userDefinedArtifactTypes.put("txt",        new ModelMime("TextDocument",    "text/plain"));
-    	    userDefinedArtifactTypes.put("properties", new ModelMime("TextDocument",    "text/plain"));
-    	    userDefinedArtifactTypes.put("css",        new ModelMime("CssDocument",     "text/css"));
-    	    userDefinedArtifactTypes.put("html",       new ModelMime("HtmlDocument",    "text/html"));
-    	    userDefinedArtifactTypes.put("ftl",        new ModelMime("FtlDocument",     "text/html"));
-    	    userDefinedArtifactTypes.put("wid",        new ModelMime("TextDocument",    "text/plain"));
-    	    userDefinedArtifactTypes.put("gif",        new ModelMime("ImageDocument",   "application/octet-stream"));
-    	    userDefinedArtifactTypes.put("png",        new ModelMime("ImageDocument",   "application/octet-stream"));
-	    }
 	}
 
 	/**
@@ -120,8 +131,8 @@ public class ArtifactType {
 			return new ArtifactType(ArtifactTypeEnum.PolicyDocument, "application/xml");
 		} else if (userDefinedArtifactTypes.containsKey(ext)){
 		    ModelMime modelMime = userDefinedArtifactTypes.get(ext);
-		    ArtifactType artifactType = new ArtifactType(ArtifactTypeEnum.UserDefinedArtifactType, modelMime.mimeType);
-		    artifactType.setUserType(modelMime.userDefinedModel);
+		    ArtifactType artifactType = ArtifactType.UserDefined(modelMime.userDefinedModel, false);
+		    artifactType.setMimeType(modelMime.mimeType);
 		    return artifactType;
 		} else {
 			return new ArtifactType(ArtifactTypeEnum.Document, null);
@@ -173,12 +184,14 @@ public class ArtifactType {
 		        artifactType.setMimeType(((DocumentArtifactType)artifact).getContentType());
 		    }
 		    if (artifactType.getArtifactType() == ArtifactTypeEnum.UserDefinedArtifactType) {
-		        if ((artifact.getOtherAttributes().keySet().contains(new QName(SrampConstants.SRAMP_CONTENT_TYPE)))) {
-		            String contentTypeStr = artifact.getOtherAttributes().get(new QName(SrampConstants.SRAMP_CONTENT_TYPE));
+		        if ((artifact.getOtherAttributes().keySet().contains(SrampConstants.SRAMP_CONTENT_TYPE_QNAME))) {
+		            String contentTypeStr = artifact.getOtherAttributes().get(SrampConstants.SRAMP_CONTENT_TYPE_QNAME);
 		            artifactType.setMimeType(contentTypeStr);
 		        }
                 String userType = ((UserDefinedArtifactType) artifact).getUserType();
+                String userDerived = artifact.getOtherAttributes().get(SrampConstants.SRAMP_DERIVED_QNAME);
                 artifactType.setUserType(userType);
+                artifactType.setUserDerivedType("true".equals(userDerived));
             }
 			return artifactType;
 		}
@@ -187,8 +200,14 @@ public class ArtifactType {
 			if (artifactTypeEnum.getTypeClass().equals(artifact.getClass())) {
 			    ArtifactType artifactType = new ArtifactType(artifactTypeEnum, null);
 			    if (artifactTypeEnum == ArtifactTypeEnum.UserDefinedArtifactType) {
+	                if ((artifact.getOtherAttributes().keySet().contains(SrampConstants.SRAMP_CONTENT_TYPE_QNAME))) {
+	                    String contentTypeStr = artifact.getOtherAttributes().get(SrampConstants.SRAMP_CONTENT_TYPE_QNAME);
+	                    artifactType.setMimeType(contentTypeStr);
+	                }
 			        String userType = ((UserDefinedArtifactType) artifact).getUserType();
+	                String userDerived = artifact.getOtherAttributes().get(SrampConstants.SRAMP_DERIVED_QNAME);
                     artifactType.setUserType(userType);
+                    artifactType.setUserDerivedType("true".equals(userDerived));
                 }
 				return artifactType;
 			}
@@ -209,7 +228,7 @@ public class ArtifactType {
                 ((DocumentArtifactType) baseArtifactType).setContentType(getMimeType());
             }
             if (getArtifactType() == ArtifactTypeEnum.UserDefinedArtifactType) {
-                baseArtifactType.getOtherAttributes().put(new QName(SrampConstants.SRAMP_CONTENT_TYPE), getMimeType());
+                baseArtifactType.getOtherAttributes().put(SrampConstants.SRAMP_CONTENT_TYPE_QNAME, getMimeType());
                 ((UserDefinedArtifactType) baseArtifactType).setUserType(getUserType());
             }
             return baseArtifactType;
@@ -237,6 +256,20 @@ public class ArtifactType {
 	 */
 	public ArtifactTypeEnum getArtifactType() {
 		return artifactType;
+	}
+
+	/**
+	 * @return true iff the type is a {@link UserDefinedArtifactType}.
+	 */
+	public boolean isUserDefinedType() {
+	    return getArtifactType() == ArtifactTypeEnum.UserDefinedArtifactType;
+	}
+
+	/**
+	 * @return true if the artifact is derived
+	 */
+	public boolean isDerived() {
+	    return getArtifactType().isDerived() || isUserDerivedType();
 	}
 
 	/**
@@ -302,16 +335,13 @@ public class ArtifactType {
         return userType;
     }
 
-    private class ModelMime {
-
+    private static class ModelMime {
         public ModelMime(String userDefinedModel, String mimeType) {
-            super();
             this.userDefinedModel = userDefinedModel;
             this.mimeType = mimeType;
         }
         public String userDefinedModel;
         public String mimeType;
-
     }
 
 	/**
@@ -350,5 +380,19 @@ public class ArtifactType {
 		}
 		return rval;
 	}
+
+    /**
+     * @return the userDerivedType
+     */
+    protected boolean isUserDerivedType() {
+        return userDerivedType;
+    }
+
+    /**
+     * @param userDerivedType the userDerivedType to set
+     */
+    public void setUserDerivedType(boolean userDerivedType) {
+        this.userDerivedType = userDerivedType;
+    }
 
 }

--- a/s-ramp-core/src/main/java/org/overlord/sramp/SrampConstants.java
+++ b/s-ramp-core/src/main/java/org/overlord/sramp/SrampConstants.java
@@ -15,6 +15,8 @@
  */
 package org.overlord.sramp;
 
+import javax.xml.namespace.QName;
+
 /**
  * Some S-RAMP constants.
  *
@@ -23,15 +25,27 @@ package org.overlord.sramp;
 public class SrampConstants {
 
     public static final String DATE_FORMAT  = "EEE, d MMM yyyy HH:mm:ss Z";
-    
+
 	public static final String SRAMP_NS     = "http://s-ramp.org/xmlns/2010/s-ramp";
 	public static final String SRAMP_PREFIX = "s-ramp";
-	
-	public static final String SRAMP_CONTENT_SIZE        = SRAMP_PREFIX + "contentSize";
-    public static final String SRAMP_CONTENT_TYPE        = SRAMP_PREFIX + "contentType";
+
+	private static final String SRAMP_CONTENT_SIZE         = "contentSize";
+	private static final String SRAMP_CONTENT_TYPE         = "contentType";
+	private static final String SRAMP_DERIVED              = "derived";
+    private static final String SRAMP_USER_TYPE            = "userType";
+    private static final String SRAMP_PROVIDER             = "provider";
+
+    public static final QName SRAMP_CONTENT_SIZE_QNAME    = new QName(SRAMP_NS, SRAMP_CONTENT_SIZE, SRAMP_PREFIX);
+    public static final QName SRAMP_CONTENT_TYPE_QNAME    = new QName(SRAMP_NS, SRAMP_CONTENT_TYPE, SRAMP_PREFIX);
+    public static final QName SRAMP_DERIVED_QNAME         = new QName(SRAMP_NS, SRAMP_DERIVED, SRAMP_PREFIX);
+    public static final QName SRAMP_PROVIDER_QNAME        = new QName(SRAMP_NS, SRAMP_PROVIDER, SRAMP_PREFIX);
+    public static final QName SRAMP_USER_TYPE_QNAME       = new QName(SRAMP_NS, SRAMP_USER_TYPE, SRAMP_PREFIX);
 
     //Configuration constants
     public static final String SRAMP_CONFIG_FILE_NAME     = "sramp.config.file.name";
     public static final String SRAMP_CONFIG_FILE_REFRESH  = "sramp.config.file.refresh";
     public static final String SRAMP_CONFIG_BASEURL       = "sramp.config.baseurl";
+
+    // Location of a directory containing JARs which provide custom derivers
+    public static final String SRAMP_CUSTOM_DERIVER_DIR   = "sramp.derivers.customDir";
 }

--- a/s-ramp-core/src/main/java/org/overlord/sramp/derived/ArtifactDeriver.java
+++ b/s-ramp-core/src/main/java/org/overlord/sramp/derived/ArtifactDeriver.java
@@ -20,7 +20,6 @@ import java.io.InputStream;
 import java.util.Collection;
 
 import org.s_ramp.xmlns._2010.s_ramp.BaseArtifactType;
-import org.s_ramp.xmlns._2010.s_ramp.DerivedArtifactType;
 
 /**
  * Provides a way to derive artifacts.  Classes that implement this interface must
@@ -39,7 +38,7 @@ public interface ArtifactDeriver {
 	 * @return derived content
 	 * @throws IOException
 	 */
-	public Collection<DerivedArtifactType> derive(BaseArtifactType artifact, InputStream contentStream)
+	public Collection<BaseArtifactType> derive(BaseArtifactType artifact, InputStream contentStream)
 			throws IOException;
 
 }

--- a/s-ramp-core/src/main/java/org/overlord/sramp/derived/DeriverProvider.java
+++ b/s-ramp-core/src/main/java/org/overlord/sramp/derived/DeriverProvider.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2012 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.overlord.sramp.derived;
+
+import java.util.Map;
+
+/**
+ * Implement this interface to provide a Deriver that will be used when an artifact
+ * of a specific user defined type is added to the repository.
+ *
+ * @author eric.wittmann@redhat.com
+ */
+public interface DeriverProvider {
+
+    /**
+     * Creates zero or more {@link ArtifactDeriver} instances to be used by the S-RAMP
+     * repository when adding user defined artifacts to the repository.
+     *
+     * @return a map of User Defined type (userType) to {@link ArtifactDeriver} instance
+     */
+    public Map<String, ArtifactDeriver> createArtifactDerivers();
+
+}

--- a/s-ramp-core/src/main/java/org/overlord/sramp/derived/IndexedArtifactCollection.java
+++ b/s-ramp-core/src/main/java/org/overlord/sramp/derived/IndexedArtifactCollection.java
@@ -22,9 +22,9 @@ import java.util.Map;
 
 import javax.xml.namespace.QName;
 
+import org.s_ramp.xmlns._2010.s_ramp.BaseArtifactType;
 import org.s_ramp.xmlns._2010.s_ramp.Binding;
 import org.s_ramp.xmlns._2010.s_ramp.ComplexTypeDeclaration;
-import org.s_ramp.xmlns._2010.s_ramp.DerivedArtifactType;
 import org.s_ramp.xmlns._2010.s_ramp.ElementDeclaration;
 import org.s_ramp.xmlns._2010.s_ramp.Message;
 import org.s_ramp.xmlns._2010.s_ramp.Operation;
@@ -39,7 +39,7 @@ import org.s_ramp.xmlns._2010.s_ramp.XsdType;
  *
  * @author eric.wittmann@redhat.com
  */
-public class IndexedArtifactCollection extends LinkedList<DerivedArtifactType> {
+public class IndexedArtifactCollection extends LinkedList<BaseArtifactType> {
 
 	private static final long serialVersionUID = 3333444885794949531L;
 
@@ -62,7 +62,7 @@ public class IndexedArtifactCollection extends LinkedList<DerivedArtifactType> {
 	 * @see java.util.LinkedList#add(java.lang.Object)
 	 */
 	@Override
-	public boolean add(DerivedArtifactType artifact) {
+	public boolean add(BaseArtifactType artifact) {
 		indexArtifact(artifact);
 		return super.add(artifact);
 	}
@@ -71,7 +71,7 @@ public class IndexedArtifactCollection extends LinkedList<DerivedArtifactType> {
 	 * Adds the given artifact to the appropriate index.
 	 * @param artifact
 	 */
-	private void indexArtifact(DerivedArtifactType artifact) {
+	private void indexArtifact(BaseArtifactType artifact) {
 		if (artifact instanceof ElementDeclaration) {
 			ElementDeclaration element = (ElementDeclaration) artifact;
 			QName key = new QName(element.getNamespace(), element.getNCName());

--- a/s-ramp-core/src/main/java/org/overlord/sramp/derived/PolicyDeriver.java
+++ b/s-ramp-core/src/main/java/org/overlord/sramp/derived/PolicyDeriver.java
@@ -16,6 +16,7 @@
 package org.overlord.sramp.derived;
 
 import java.io.IOException;
+import java.util.Collection;
 
 import javax.xml.xpath.XPath;
 
@@ -53,10 +54,10 @@ public class PolicyDeriver extends AbstractXmlDeriver {
 	}
 
 	/**
-	 * @see org.overlord.sramp.repository.derived.AbstractXmlDeriver#derive(org.overlord.sramp.repository.derived.IndexedArtifactCollection, org.s_ramp.xmlns._2010.s_ramp.BaseArtifactType, org.w3c.dom.Element, javax.xml.xpath.XPath)
+	 * @see org.overlord.sramp.derived.AbstractXmlDeriver#derive(java.util.Collection, org.s_ramp.xmlns._2010.s_ramp.BaseArtifactType, org.w3c.dom.Element, javax.xml.xpath.XPath)
 	 */
 	@Override
-	protected void derive(IndexedArtifactCollection derivedArtifacts, BaseArtifactType artifact,
+	protected void derive(Collection<BaseArtifactType> derivedArtifacts, BaseArtifactType artifact,
 			Element rootElement, XPath xpath) throws IOException {
 	}
 }

--- a/s-ramp-core/src/main/java/org/overlord/sramp/derived/WsdlDeriver.java
+++ b/s-ramp-core/src/main/java/org/overlord/sramp/derived/WsdlDeriver.java
@@ -133,16 +133,24 @@ public class WsdlDeriver extends XsdDeriver {
 	}
 
 	/**
+	 * @see org.overlord.sramp.derived.AbstractXmlDeriver#createDerivedArtifactCollection()
+	 */
+	@Override
+	protected Collection<BaseArtifactType> createDerivedArtifactCollection() {
+	    return new IndexedArtifactCollection();
+	}
+
+	/**
 	 * @see org.overlord.sramp.repository.derived.XsdDeriver#derive(org.overlord.sramp.repository.derived.IndexedArtifactCollection, org.s_ramp.xmlns._2010.s_ramp.BaseArtifactType, org.w3c.dom.Element, javax.xml.xpath.XPath)
 	 */
 	@Override
-	protected void derive(IndexedArtifactCollection derivedArtifacts, BaseArtifactType artifact,
+	protected void derive(Collection<BaseArtifactType> derivedArtifacts, BaseArtifactType artifact,
 			Element rootElement, XPath xpath) throws IOException {
 		String targetNS = rootElement.getAttribute("targetNamespace");
 		((WsdlDocument) artifact).setTargetNamespace(targetNS);
 
 		try {
-			processDefinitions(derivedArtifacts, artifact, rootElement, xpath);
+			processDefinitions((IndexedArtifactCollection) derivedArtifacts, artifact, rootElement, xpath);
 		} catch (Exception e) {
 			throw new IOException(e);
 		}

--- a/s-ramp-core/src/main/java/org/overlord/sramp/derived/XsdDeriver.java
+++ b/s-ramp-core/src/main/java/org/overlord/sramp/derived/XsdDeriver.java
@@ -28,7 +28,6 @@ import org.s_ramp.xmlns._2010.s_ramp.AttributeDeclaration;
 import org.s_ramp.xmlns._2010.s_ramp.BaseArtifactEnum;
 import org.s_ramp.xmlns._2010.s_ramp.BaseArtifactType;
 import org.s_ramp.xmlns._2010.s_ramp.ComplexTypeDeclaration;
-import org.s_ramp.xmlns._2010.s_ramp.DerivedArtifactType;
 import org.s_ramp.xmlns._2010.s_ramp.ElementDeclaration;
 import org.s_ramp.xmlns._2010.s_ramp.SimpleTypeDeclaration;
 import org.w3c.dom.Element;
@@ -68,10 +67,10 @@ public class XsdDeriver extends AbstractXmlDeriver {
 	}
 
 	/**
-	 * @see org.overlord.sramp.repository.derived.AbstractXmlDeriver#derive(org.overlord.sramp.repository.derived.IndexedArtifactCollection, org.s_ramp.xmlns._2010.s_ramp.BaseArtifactType, org.w3c.dom.Element, javax.xml.xpath.XPath)
+	 * @see org.overlord.sramp.derived.AbstractXmlDeriver#derive(java.util.Collection, org.s_ramp.xmlns._2010.s_ramp.BaseArtifactType, org.w3c.dom.Element, javax.xml.xpath.XPath)
 	 */
 	@Override
-	protected void derive(IndexedArtifactCollection derivedArtifacts, BaseArtifactType artifact,
+	protected void derive(Collection<BaseArtifactType> derivedArtifacts, BaseArtifactType artifact,
 			Element rootElement, XPath xpath) throws IOException {
 		try {
 			processSchema(derivedArtifacts, artifact, rootElement, xpath);
@@ -88,7 +87,7 @@ public class XsdDeriver extends AbstractXmlDeriver {
 	 * @param xpath
 	 * @throws XPathExpressionException
 	 */
-	public void processSchema(Collection<DerivedArtifactType> derivedArtifacts,
+	public void processSchema(Collection<BaseArtifactType> derivedArtifacts,
 			BaseArtifactType artifact, Element schema, XPath xpath) throws XPathExpressionException {
 		processElementDeclarations(derivedArtifacts, artifact, schema, xpath);
 		processAttributeDeclarations(derivedArtifacts, artifact, schema, xpath);
@@ -97,7 +96,7 @@ public class XsdDeriver extends AbstractXmlDeriver {
 
 		// Pre-set the UUIDs for all the derived artifacts.  This is useful
 		// if something downstream needs to reference them.
-		for (DerivedArtifactType derivedArtifact : derivedArtifacts) {
+		for (BaseArtifactType derivedArtifact : derivedArtifacts) {
 			derivedArtifact.setUuid(UUID.randomUUID().toString());
 		}
 	}
@@ -110,7 +109,7 @@ public class XsdDeriver extends AbstractXmlDeriver {
 	 * @param xpath
 	 * @throws XPathExpressionException
 	 */
-	private void processElementDeclarations(Collection<DerivedArtifactType> derivedArtifacts,
+	private void processElementDeclarations(Collection<BaseArtifactType> derivedArtifacts,
 			BaseArtifactType sourceArtifact, Element schema, XPath xpath) throws XPathExpressionException {
 		String targetNS = schema.getAttribute("targetNamespace");
 
@@ -138,7 +137,7 @@ public class XsdDeriver extends AbstractXmlDeriver {
 	 * @param xpath
 	 * @throws XPathExpressionException
 	 */
-	private void processAttributeDeclarations(Collection<DerivedArtifactType> derivedArtifacts,
+	private void processAttributeDeclarations(Collection<BaseArtifactType> derivedArtifacts,
 			BaseArtifactType sourceArtifact, Element schema, XPath xpath) throws XPathExpressionException {
 		String targetNS = schema.getAttribute("targetNamespace");
 
@@ -166,7 +165,7 @@ public class XsdDeriver extends AbstractXmlDeriver {
 	 * @param xpath
 	 * @throws XPathExpressionException
 	 */
-	private void processSimpleTypeDeclarations(Collection<DerivedArtifactType> derivedArtifacts,
+	private void processSimpleTypeDeclarations(Collection<BaseArtifactType> derivedArtifacts,
 			BaseArtifactType sourceArtifact, Element schema, XPath xpath) throws XPathExpressionException {
 		String targetNS = schema.getAttribute("targetNamespace");
 
@@ -194,7 +193,7 @@ public class XsdDeriver extends AbstractXmlDeriver {
 	 * @param xpath
 	 * @throws XPathExpressionException
 	 */
-	private void processComplexTypeDeclarations(Collection<DerivedArtifactType> derivedArtifacts,
+	private void processComplexTypeDeclarations(Collection<BaseArtifactType> derivedArtifacts,
 			BaseArtifactType sourceArtifact, Element schema, XPath xpath) throws XPathExpressionException {
 		String targetNS = schema.getAttribute("targetNamespace");
 

--- a/s-ramp-core/src/test/java/org/overlord/sramp/derived/WsdlDeriverTest.java
+++ b/s-ramp-core/src/test/java/org/overlord/sramp/derived/WsdlDeriverTest.java
@@ -32,6 +32,7 @@ import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 import org.s_ramp.xmlns._2010.s_ramp.AttributeDeclaration;
 import org.s_ramp.xmlns._2010.s_ramp.BaseArtifactEnum;
+import org.s_ramp.xmlns._2010.s_ramp.BaseArtifactType;
 import org.s_ramp.xmlns._2010.s_ramp.Binding;
 import org.s_ramp.xmlns._2010.s_ramp.BindingOperation;
 import org.s_ramp.xmlns._2010.s_ramp.BindingOperationInput;
@@ -87,13 +88,14 @@ public class WsdlDeriverTest {
 		InputStream testSrcContent = null;
 		try {
 			testSrcContent = getClass().getResourceAsStream("/sample-files/wsdl/deriver.wsdl");
-			Collection<DerivedArtifactType> derivedArtifacts = deriver.derive(testSrcArtifact, testSrcContent);
+			Collection<BaseArtifactType> derivedArtifacts = deriver.derive(testSrcArtifact, testSrcContent);
 			Assert.assertNotNull(derivedArtifacts);
 			Assert.assertEquals(35, derivedArtifacts.size());
 
 			// Index the results by artifact type and name
 			Map<QName, DerivedArtifactType> index = new HashMap<QName, DerivedArtifactType>();
-			for (DerivedArtifactType artifact : derivedArtifacts) {
+			for (BaseArtifactType da : derivedArtifacts) {
+			    DerivedArtifactType artifact = (DerivedArtifactType) da;
 				if (artifact instanceof NamedWsdlDerivedArtifactType) {
 					NamedWsdlDerivedArtifactType arty = (NamedWsdlDerivedArtifactType) artifact;
 					if (arty.getNCName() != null)
@@ -312,7 +314,7 @@ public class WsdlDeriverTest {
 		InputStream testSrcContent = null;
 		try {
 			testSrcContent = getClass().getResourceAsStream("/sample-files/wsdl/ws-humantask-api.wsdl");
-			Collection<DerivedArtifactType> derivedArtifacts = deriver.derive(testSrcArtifact, testSrcContent);
+			Collection<BaseArtifactType> derivedArtifacts = deriver.derive(testSrcArtifact, testSrcContent);
 			Assert.assertNotNull(derivedArtifacts);
 			Assert.assertEquals(850, derivedArtifacts.size());
 		} finally {

--- a/s-ramp-core/src/test/java/org/overlord/sramp/derived/XsdDeriverTest.java
+++ b/s-ramp-core/src/test/java/org/overlord/sramp/derived/XsdDeriverTest.java
@@ -31,6 +31,7 @@ import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 import org.s_ramp.xmlns._2010.s_ramp.AttributeDeclaration;
 import org.s_ramp.xmlns._2010.s_ramp.BaseArtifactEnum;
+import org.s_ramp.xmlns._2010.s_ramp.BaseArtifactType;
 import org.s_ramp.xmlns._2010.s_ramp.ComplexTypeDeclaration;
 import org.s_ramp.xmlns._2010.s_ramp.DerivedArtifactType;
 import org.s_ramp.xmlns._2010.s_ramp.DocumentArtifactEnum;
@@ -92,7 +93,7 @@ public class XsdDeriverTest {
 		InputStream testSrcContent = null;
 		try {
 			testSrcContent = getClass().getResourceAsStream("/sample-files/xsd/ws-humantask.xsd");
-			Collection<DerivedArtifactType> derivedArtifacts = deriver.derive(testSrcArtifact, testSrcContent);
+			Collection<BaseArtifactType> derivedArtifacts = deriver.derive(testSrcArtifact, testSrcContent);
 			Assert.assertNotNull(derivedArtifacts);
 			Assert.assertEquals(83, derivedArtifacts.size());
 			int numElements = 0;
@@ -103,7 +104,8 @@ public class XsdDeriverTest {
 			Set<String> attributeNames = new HashSet<String>();
 			Set<String> simpleTypeNames = new HashSet<String>();
 			Set<String> complexTypeNames = new HashSet<String>();
-			for (DerivedArtifactType dat : derivedArtifacts) {
+			for (BaseArtifactType derivedArtifact : derivedArtifacts) {
+			    DerivedArtifactType dat = (DerivedArtifactType) derivedArtifact;
 				Assert.assertEquals(testSrcArtifact.getUuid(), dat.getRelatedDocument().getValue());
 				Assert.assertEquals(DocumentArtifactEnum.XSD_DOCUMENT, dat.getRelatedDocument().getArtifactType());
 

--- a/s-ramp-repository-jcr/src/main/java/org/overlord/sramp/repository/jcr/mapper/ArtifactToJCRNodeVisitor.java
+++ b/s-ramp-repository-jcr/src/main/java/org/overlord/sramp/repository/jcr/mapper/ArtifactToJCRNodeVisitor.java
@@ -36,6 +36,7 @@ import javax.jcr.lock.LockException;
 import javax.jcr.nodetype.ConstraintViolationException;
 import javax.jcr.version.VersionException;
 
+import org.overlord.sramp.ArtifactType;
 import org.overlord.sramp.SrampException;
 import org.overlord.sramp.repository.jcr.ClassificationHelper;
 import org.overlord.sramp.repository.jcr.JCRConstants;
@@ -86,6 +87,7 @@ import org.s_ramp.xmlns._2010.s_ramp.XsdTypeEnum;
  */
 public class ArtifactToJCRNodeVisitor extends HierarchicalArtifactVisitorAdapter {
 
+    private ArtifactType artifactType;
 	private Node jcrNode;
 	private Exception error;
 	private JCRReferenceFactory referenceFactory;
@@ -93,11 +95,13 @@ public class ArtifactToJCRNodeVisitor extends HierarchicalArtifactVisitorAdapter
 
 	/**
 	 * Constructor.
+     * @param artifactType the type of the artifact being persisted
 	 * @param jcrNode the JCR node this visitor will be updating
 	 * @param referenceFactory a resolver to find JCR nodes by UUID
 	 * @param classificationHelper helps resolve, verify, and normalize classifications
 	 */
-	public ArtifactToJCRNodeVisitor(Node jcrNode, JCRReferenceFactory referenceFactory, ClassificationHelper classificationHelper) {
+	public ArtifactToJCRNodeVisitor(ArtifactType artifactType, Node jcrNode, JCRReferenceFactory referenceFactory, ClassificationHelper classificationHelper) {
+	    this.artifactType = artifactType;
 		this.jcrNode = jcrNode;
 		this.referenceFactory = referenceFactory;
 		this.classificationHelper = classificationHelper;
@@ -165,10 +169,13 @@ public class ArtifactToJCRNodeVisitor extends HierarchicalArtifactVisitorAdapter
 	private void updateArtifactMetaData(BaseArtifactType artifact) throws Exception {
 		if (artifact.getName() != null)
 			this.jcrNode.setProperty("sramp:name", artifact.getName());
+		else
+		    this.jcrNode.setProperty("sramp:name", artifact.getClass().getSimpleName());
 		if (artifact.getDescription() != null)
 			this.jcrNode.setProperty("sramp:description", artifact.getDescription());
 		if (artifact.getVersion() != null)
 			this.jcrNode.setProperty("version", artifact.getVersion());
+		this.jcrNode.setProperty("sramp:derived", this.artifactType.isDerived());
 	}
 
 	/**

--- a/s-ramp-repository-jcr/src/main/java/org/overlord/sramp/repository/jcr/mapper/JCRNodeToArtifactVisitor.java
+++ b/s-ramp-repository-jcr/src/main/java/org/overlord/sramp/repository/jcr/mapper/JCRNodeToArtifactVisitor.java
@@ -29,7 +29,6 @@ import javax.jcr.Value;
 import javax.jcr.ValueFormatException;
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.XMLGregorianCalendar;
-import javax.xml.namespace.QName;
 
 import org.overlord.sramp.ArtifactType;
 import org.overlord.sramp.SrampConstants;
@@ -264,9 +263,17 @@ public class JCRNodeToArtifactVisitor extends HierarchicalArtifactVisitorAdapter
 	 */
 	@Override
 	protected void visitUserDefined(UserDefinedArtifactType artifact) {
-		artifact.setUserType(getProperty(jcrNode, "sramp:userType"));
-		artifact.getOtherAttributes().put(new QName(SrampConstants.SRAMP_CONTENT_SIZE), String.valueOf(getPropertyLength(jcrNode,"jcr:content/jcr:data")));
-		artifact.getOtherAttributes().put(new QName(SrampConstants.SRAMP_CONTENT_TYPE), getProperty(jcrNode,"jcr:content/jcr:mimeType"));
+        String userType = getProperty(jcrNode, "sramp:userType");
+        String contentType = getProperty(jcrNode,"jcr:content/jcr:mimeType");
+        String contentLength = String.valueOf(getPropertyLength(jcrNode,"jcr:content/jcr:data"));
+        String userDerived = getProperty(jcrNode, "sramp:derived", "false");
+
+        artifact.setUserType(userType);
+		if (contentType != null && contentLength != null) {
+            artifact.getOtherAttributes().put(SrampConstants.SRAMP_CONTENT_SIZE_QNAME, contentLength);
+            artifact.getOtherAttributes().put(SrampConstants.SRAMP_CONTENT_TYPE_QNAME, contentType);
+		}
+        artifact.getOtherAttributes().put(SrampConstants.SRAMP_DERIVED_QNAME, userDerived);
 	}
 
 	/**

--- a/s-ramp-repository-jcr/src/main/java/org/overlord/sramp/repository/jcr/query/SrampToJcrSql2QueryVisitor.java
+++ b/s-ramp-repository-jcr/src/main/java/org/overlord/sramp/repository/jcr/query/SrampToJcrSql2QueryVisitor.java
@@ -78,6 +78,8 @@ public class SrampToJcrSql2QueryVisitor implements XPathVisitor {
 		corePropertyMap.put(new QName(SrampConstants.SRAMP_NS, "style"), "sramp:style");
 		corePropertyMap.put(new QName(SrampConstants.SRAMP_NS, "transport"), "sramp:transport");
 		corePropertyMap.put(new QName(SrampConstants.SRAMP_NS, "soapLocation"), "sramp:soapLocation");
+
+        corePropertyMap.put(new QName(SrampConstants.SRAMP_NS, "derived"), "sramp:derived");
 	}
 
 	private StringBuilder fromBuilder = new StringBuilder();

--- a/s-ramp-repository-jcr/src/main/resources/org/overlord/s-ramp/sramp.cnd
+++ b/s-ramp-repository-jcr/src/main/resources/org/overlord/s-ramp/sramp.cnd
@@ -45,6 +45,7 @@
 - sramp:id (string)
 + * (sramp:class)
 
+
 // -------------------------------------------------------
 // S-RAMP Core Model Artifacts
 // -------------------------------------------------------
@@ -64,6 +65,7 @@
 - sramp:classifiedBy (string) multiple
 - sramp:normalizedClassifiedBy (string) multiple
 - sramp:description (string)
+- sramp:derived (boolean)
 - * (string)
 - * (string) multiple
 + * (sramp:relationship)
@@ -79,8 +81,13 @@
 
 [sramp:derivedArtifactType] > sramp:baseArtifactType abstract mixin
 
+// Special case of a user defined type that is derived.
+[sramp:userDefinedDerivedArtifactType] > sramp:baseArtifactType
+- sramp:userType (string)
+
 [sramp:userDefinedArtifactType] > sramp:baseArtifactType mixin
 - sramp:userType (string) mandatory
++ * (sramp:userDefinedDerivedArtifactType)
 
 [sramp:storedQuery] > nt:query
 - sramp:propertyList (string) multiple

--- a/s-ramp-repository-jcr/src/test/java/org/overlord/sramp/repository/jcr/JCRClassificationPersistenceTest.java
+++ b/s-ramp-repository-jcr/src/test/java/org/overlord/sramp/repository/jcr/JCRClassificationPersistenceTest.java
@@ -49,10 +49,10 @@ public class JCRClassificationPersistenceTest extends AbstractJCRPersistenceTest
         BaseArtifactType artifact = persistenceManager.persistArtifact(document, contentStream);
         Assert.assertNotNull(artifact);
         if (log.isDebugEnabled()) {
-            persistenceManager.printArtifactGraph(artifact.getUuid(), ArtifactType.Document);
+            persistenceManager.printArtifactGraph(artifact.getUuid(), ArtifactType.Document());
         }
 
-        artifact = persistenceManager.getArtifact(artifact.getUuid(), ArtifactType.Document);
+        artifact = persistenceManager.getArtifact(artifact.getUuid(), ArtifactType.Document());
 
         Assert.assertNotNull(artifact.getClassifiedBy());
         Assert.assertEquals(1, artifact.getClassifiedBy().size());

--- a/s-ramp-repository-jcr/src/test/java/org/overlord/sramp/repository/jcr/JCRPersistenceTest.java
+++ b/s-ramp-repository-jcr/src/test/java/org/overlord/sramp/repository/jcr/JCRPersistenceTest.java
@@ -55,7 +55,7 @@ public class JCRPersistenceTest extends AbstractJCRPersistenceTest {
 
         //print out the derived node
         if (log.isDebugEnabled()) {
-            persistenceManager.printArtifactGraph(artifact.getUuid(), ArtifactType.Document);
+            persistenceManager.printArtifactGraph(artifact.getUuid(), ArtifactType.Document());
         }
         Assert.assertEquals(Document.class, artifact.getClass());
         Assert.assertEquals(new Long(18873l), ((Document) artifact).getContentSize());
@@ -76,7 +76,7 @@ public class JCRPersistenceTest extends AbstractJCRPersistenceTest {
 
         //print out the derived node
         if (log.isDebugEnabled()) {
-            persistenceManager.printArtifactGraph(artifact.getUuid(), ArtifactType.XsdDocument);
+            persistenceManager.printArtifactGraph(artifact.getUuid(), ArtifactType.XsdDocument());
         }
 
         Assert.assertEquals(XsdDocument.class, artifact.getClass());
@@ -99,7 +99,7 @@ public class JCRPersistenceTest extends AbstractJCRPersistenceTest {
 
         //print out the derived node
         if (log.isDebugEnabled()) {
-            persistenceManager.printArtifactGraph(artifact.getUuid(), ArtifactType.XmlDocument);
+            persistenceManager.printArtifactGraph(artifact.getUuid(), ArtifactType.XmlDocument());
         }
         Assert.assertEquals(XmlDocument.class, artifact.getClass());
         Assert.assertEquals(new Long(825l), ((XmlDocument) artifact).getContentSize());
@@ -121,7 +121,7 @@ public class JCRPersistenceTest extends AbstractJCRPersistenceTest {
         Assert.assertEquals(XsdDocument.class, artifact.getClass());
         Assert.assertEquals(new Long(2376l), ((XsdDocument) artifact).getContentSize());
 
-        BaseArtifactType artifact2 = persistenceManager.getArtifact(artifact.getUuid(), ArtifactType.XsdDocument);
+        BaseArtifactType artifact2 = persistenceManager.getArtifact(artifact.getUuid(), ArtifactType.XsdDocument());
         Assert.assertEquals(artifact.getUuid(), artifact2.getUuid());
         Assert.assertEquals(artifact.getCreatedBy(), artifact2.getCreatedBy());
         Assert.assertEquals(artifact.getDescription(), artifact2.getDescription());
@@ -151,14 +151,14 @@ public class JCRPersistenceTest extends AbstractJCRPersistenceTest {
         Assert.assertEquals(artifactFileName, artifact.getName());
 
         // Now update the artifact
-        artifact = persistenceManager.getArtifact(artifact.getUuid(), ArtifactType.XsdDocument);
+        artifact = persistenceManager.getArtifact(artifact.getUuid(), ArtifactType.XsdDocument());
         artifact.setName("My PO");
         artifact.setDescription("A new description of the PO.xsd artifact.");
         artifact.setVersion("2.0.13");
-        persistenceManager.updateArtifact(artifact, ArtifactType.XsdDocument);
+        persistenceManager.updateArtifact(artifact, ArtifactType.XsdDocument());
 
         // Now verify the meta-data was updated
-        artifact = persistenceManager.getArtifact(artifact.getUuid(), ArtifactType.XsdDocument);
+        artifact = persistenceManager.getArtifact(artifact.getUuid(), ArtifactType.XsdDocument());
         Assert.assertEquals("My PO", artifact.getName());
         Assert.assertEquals("A new description of the PO.xsd artifact.", artifact.getDescription());
         Assert.assertEquals("2.0.13", artifact.getVersion());
@@ -185,10 +185,10 @@ public class JCRPersistenceTest extends AbstractJCRPersistenceTest {
 
         // Now update the artifact content
         InputStream otherXsd = this.getClass().getResourceAsStream("/sample-files/xsd/XMLSchema.xsd");
-        persistenceManager.updateArtifactContent(artifact.getUuid(), ArtifactType.XsdDocument, otherXsd);
+        persistenceManager.updateArtifactContent(artifact.getUuid(), ArtifactType.XsdDocument(), otherXsd);
 
         // Now verify the content was updated
-        artifact = persistenceManager.getArtifact(artifact.getUuid(), ArtifactType.XsdDocument);
+        artifact = persistenceManager.getArtifact(artifact.getUuid(), ArtifactType.XsdDocument());
         Assert.assertEquals(new Long(87677), ((XsdDocument) artifact).getContentSize());
     }
 
@@ -211,7 +211,7 @@ public class JCRPersistenceTest extends AbstractJCRPersistenceTest {
         Assert.assertEquals(new Long(2376l), ((XsdDocument) artifact).getContentSize());
 
         // Now update the artifact
-        artifact = persistenceManager.getArtifact(artifact.getUuid(), ArtifactType.XsdDocument);
+        artifact = persistenceManager.getArtifact(artifact.getUuid(), ArtifactType.XsdDocument());
         Assert.assertTrue("Expected 0 properties.", artifact.getProperty().isEmpty());
         Property prop1 = new Property();
         prop1.setPropertyName("prop1");
@@ -221,10 +221,10 @@ public class JCRPersistenceTest extends AbstractJCRPersistenceTest {
         prop2.setPropertyName("prop2");
         prop2.setPropertyValue("propval2");
         artifact.getProperty().add(prop2);
-        persistenceManager.updateArtifact(artifact, ArtifactType.XsdDocument);
+        persistenceManager.updateArtifact(artifact, ArtifactType.XsdDocument());
 
         // Now verify that the properties were stored
-        artifact = persistenceManager.getArtifact(artifact.getUuid(), ArtifactType.XsdDocument);
+        artifact = persistenceManager.getArtifact(artifact.getUuid(), ArtifactType.XsdDocument());
         Assert.assertTrue("Expected 2 properties.", artifact.getProperty().size() == 2);
         String p1 = artifact.getProperty().get(0).getPropertyName() + "=" + artifact.getProperty().get(0).getPropertyValue();
         String p2 = artifact.getProperty().get(1).getPropertyName() + "=" + artifact.getProperty().get(1).getPropertyValue();
@@ -245,10 +245,10 @@ public class JCRPersistenceTest extends AbstractJCRPersistenceTest {
         prop3.setPropertyName("prop3");
         prop3.setPropertyValue("propval3");
         artifact.getProperty().add(prop3);
-        persistenceManager.updateArtifact(artifact, ArtifactType.XsdDocument);
+        persistenceManager.updateArtifact(artifact, ArtifactType.XsdDocument());
 
         // Now verify that the properties were updated
-        artifact = persistenceManager.getArtifact(artifact.getUuid(), ArtifactType.XsdDocument);
+        artifact = persistenceManager.getArtifact(artifact.getUuid(), ArtifactType.XsdDocument());
         Assert.assertTrue("Expected 2 properties.", artifact.getProperty().size() == 2);
         p1 = artifact.getProperty().get(0).getPropertyName() + "=" + artifact.getProperty().get(0).getPropertyValue();
         p2 = artifact.getProperty().get(1).getPropertyName() + "=" + artifact.getProperty().get(1).getPropertyValue();
@@ -282,7 +282,7 @@ public class JCRPersistenceTest extends AbstractJCRPersistenceTest {
         Assert.assertEquals(new Long(18873l), ((Document) artifact).getContentSize());
 
         // Now update the artifact
-        artifact = persistenceManager.getArtifact(artifact.getUuid(), ArtifactType.Document);
+        artifact = persistenceManager.getArtifact(artifact.getUuid(), ArtifactType.Document());
         Assert.assertTrue("Expected 0 properties.", artifact.getProperty().isEmpty());
         Property prop1 = new Property();
         prop1.setPropertyName("prop1");
@@ -292,10 +292,10 @@ public class JCRPersistenceTest extends AbstractJCRPersistenceTest {
         prop2.setPropertyName("prop2");
         prop2.setPropertyValue("propval2");
         artifact.getProperty().add(prop2);
-        persistenceManager.updateArtifact(artifact, ArtifactType.Document);
+        persistenceManager.updateArtifact(artifact, ArtifactType.Document());
 
         // Now verify that the properties were stored
-        artifact = persistenceManager.getArtifact(artifact.getUuid(), ArtifactType.Document);
+        artifact = persistenceManager.getArtifact(artifact.getUuid(), ArtifactType.Document());
         Assert.assertTrue("Expected 2 properties.", artifact.getProperty().size() == 2);
         String p1 = artifact.getProperty().get(0).getPropertyName() + "=" + artifact.getProperty().get(0).getPropertyValue();
         String p2 = artifact.getProperty().get(1).getPropertyName() + "=" + artifact.getProperty().get(1).getPropertyValue();
@@ -316,10 +316,10 @@ public class JCRPersistenceTest extends AbstractJCRPersistenceTest {
         prop3.setPropertyName("prop3");
         prop3.setPropertyValue("propval3");
         artifact.getProperty().add(prop3);
-        persistenceManager.updateArtifact(artifact, ArtifactType.Document);
+        persistenceManager.updateArtifact(artifact, ArtifactType.Document());
 
         // Now verify that the properties were updated
-        artifact = persistenceManager.getArtifact(artifact.getUuid(), ArtifactType.Document);
+        artifact = persistenceManager.getArtifact(artifact.getUuid(), ArtifactType.Document());
         Assert.assertTrue("Expected 2 properties.", artifact.getProperty().size() == 2);
         p1 = artifact.getProperty().get(0).getPropertyName() + "=" + artifact.getProperty().get(0).getPropertyValue();
         p2 = artifact.getProperty().get(1).getPropertyName() + "=" + artifact.getProperty().get(1).getPropertyValue();
@@ -354,13 +354,13 @@ public class JCRPersistenceTest extends AbstractJCRPersistenceTest {
         contentStream.close();
 
         // Now update the artifact's generic relationships
-        artifact = persistenceManager.getArtifact(uuid1, ArtifactType.XsdDocument);
+        artifact = persistenceManager.getArtifact(uuid1, ArtifactType.XsdDocument());
         Assert.assertTrue("Expected 0 relationships.", artifact.getRelationship().isEmpty());
         SrampModelUtils.addGenericRelationship(artifact, "NoTargetRelationship", null);
-        persistenceManager.updateArtifact(artifact, ArtifactType.XsdDocument);
+        persistenceManager.updateArtifact(artifact, ArtifactType.XsdDocument());
 
         // Now verify that the relationship was stored
-        artifact = persistenceManager.getArtifact(artifact.getUuid(), ArtifactType.XsdDocument);
+        artifact = persistenceManager.getArtifact(artifact.getUuid(), ArtifactType.XsdDocument());
         Assert.assertEquals("Expected 1 relationship.", 1, artifact.getRelationship().size());
         Assert.assertEquals("NoTargetRelationship", artifact.getRelationship().get(0).getRelationshipType());
         Assert.assertEquals(Collections.EMPTY_LIST, artifact.getRelationship().get(0).getRelationshipTarget());
@@ -377,10 +377,10 @@ public class JCRPersistenceTest extends AbstractJCRPersistenceTest {
 
         // Add a second relationship, this time with a target.
         SrampModelUtils.addGenericRelationship(artifact, "TargetedRelationship", uuid2);
-        persistenceManager.updateArtifact(artifact, ArtifactType.XsdDocument);
+        persistenceManager.updateArtifact(artifact, ArtifactType.XsdDocument());
 
         // Now verify that the targeted relationship was stored
-        artifact = persistenceManager.getArtifact(uuid1, ArtifactType.XsdDocument);
+        artifact = persistenceManager.getArtifact(uuid1, ArtifactType.XsdDocument());
         Assert.assertEquals("Expected 2 relationships.", 2, artifact.getRelationship().size());
         Relationship relationship = SrampModelUtils.getGenericRelationship(artifact, "NoTargetRelationship");
         Assert.assertNotNull(relationship);
@@ -405,10 +405,10 @@ public class JCRPersistenceTest extends AbstractJCRPersistenceTest {
 
         // Add a third relationship, again with a target.
         SrampModelUtils.addGenericRelationship(artifact, "TargetedRelationship", uuid3);
-        persistenceManager.updateArtifact(artifact, ArtifactType.XsdDocument);
+        persistenceManager.updateArtifact(artifact, ArtifactType.XsdDocument());
 
         // More verifications
-        artifact = persistenceManager.getArtifact(uuid1, ArtifactType.XsdDocument);
+        artifact = persistenceManager.getArtifact(uuid1, ArtifactType.XsdDocument());
         Assert.assertEquals("Expected 2 relationships.", 2, artifact.getRelationship().size());
         relationship = SrampModelUtils.getGenericRelationship(artifact, "NoTargetRelationship");
         Assert.assertNotNull(relationship);
@@ -429,7 +429,7 @@ public class JCRPersistenceTest extends AbstractJCRPersistenceTest {
         // Add a fourth (bogus) relationship
         SrampModelUtils.addGenericRelationship(artifact, "TargetedRelationship", "not-a-valid-uuid");
     	try {
-			persistenceManager.updateArtifact(artifact, ArtifactType.XsdDocument);
+			persistenceManager.updateArtifact(artifact, ArtifactType.XsdDocument());
 			Assert.fail("Expected an update failure.");
 		} catch (Exception e) {
 		    Assert.assertEquals(ArtifactNotFoundException.class, e.getClass());

--- a/s-ramp-repository-jcr/src/test/java/org/overlord/sramp/repository/jcr/JCRQueryManagerTest.java
+++ b/s-ramp-repository-jcr/src/test/java/org/overlord/sramp/repository/jcr/JCRQueryManagerTest.java
@@ -84,12 +84,12 @@ public class JCRQueryManagerTest extends AbstractJCRPersistenceTest {
         SrampModelUtils.setCustomProperty(artifact2, "prop3", uniquePropVal3);
         SrampModelUtils.setCustomProperty(artifact3, "prop3", uniquePropVal3);
 
-        persistenceManager.updateArtifact(artifact1, ArtifactType.Document);
-        persistenceManager.updateArtifact(artifact2, ArtifactType.Document);
-        persistenceManager.updateArtifact(artifact3, ArtifactType.Document);
+        persistenceManager.updateArtifact(artifact1, ArtifactType.Document());
+        persistenceManager.updateArtifact(artifact2, ArtifactType.Document());
+        persistenceManager.updateArtifact(artifact3, ArtifactType.Document());
 
         // Now query by various properties
-        persistenceManager.printArtifactGraph(artifact1.getUuid(), ArtifactType.Document);
+        persistenceManager.printArtifactGraph(artifact1.getUuid(), ArtifactType.Document());
         SrampQuery query = queryManager.createQuery("/s-ramp/core/Document[@prop1 = ?]");
         query.setString(uniquePropVal1);
         ArtifactSet artifactSet = query.executeQuery();

--- a/s-ramp-repository-jcr/src/test/java/org/overlord/sramp/repository/jcr/JCRRelationshipQueryTest.java
+++ b/s-ramp-repository-jcr/src/test/java/org/overlord/sramp/repository/jcr/JCRRelationshipQueryTest.java
@@ -95,7 +95,7 @@ public class JCRRelationshipQueryTest extends AbstractJCRPersistenceTest {
     	SrampModelUtils.addGenericRelationship(xsdDoc, "importedBy", wsdlDoc.getUuid());
     	SrampModelUtils.addGenericRelationship(xsdDoc, "markerRel", null);
 
-    	persistenceManager.updateArtifact(xsdDoc, ArtifactType.XsdDocument);
+    	persistenceManager.updateArtifact(xsdDoc, ArtifactType.XsdDocument());
 
         SrampQuery query = queryManager.createQuery("/s-ramp/xsd/XsdDocument[markerRel]");
         ArtifactSet artifactSet = query.executeQuery();

--- a/s-ramp-repository-jcr/src/test/java/org/overlord/sramp/repository/jcr/query/SrampToJcrSql2QueryVisitorTest.java
+++ b/s-ramp-repository-jcr/src/test/java/org/overlord/sramp/repository/jcr/query/SrampToJcrSql2QueryVisitorTest.java
@@ -46,6 +46,10 @@ public class SrampToJcrSql2QueryVisitorTest {
 			"/s-ramp/xsd",
 			"SELECT artifact.* FROM [sramp:baseArtifactType] AS artifact WHERE artifact.[sramp:artifactModel] = 'xsd'"
 		},
+        {
+            "/s-ramp/xsd[@derived = 'true']",
+            "SELECT artifact.* FROM [sramp:baseArtifactType] AS artifact WHERE artifact.[sramp:artifactModel] = 'xsd' AND (artifact.[sramp:derived] = 'true')"
+        },
 		{
 			"/s-ramp",
 			"SELECT artifact.* FROM [sramp:baseArtifactType] AS artifact WHERE artifact.[sramp:artifactModel] LIKE '%'"

--- a/s-ramp-repository/src/main/java/org/overlord/sramp/repository/DerivedArtifacts.java
+++ b/s-ramp-repository/src/main/java/org/overlord/sramp/repository/DerivedArtifacts.java
@@ -20,7 +20,6 @@ import java.util.Collection;
 
 import org.overlord.sramp.SrampException;
 import org.s_ramp.xmlns._2010.s_ramp.BaseArtifactType;
-import org.s_ramp.xmlns._2010.s_ramp.DerivedArtifactType;
 
 /**
  * A service that can rip apart an artifact (previously persisted) and create all of its Derived Artifacts.
@@ -33,7 +32,7 @@ public interface DerivedArtifacts {
 	 * @param sourceArtifact the source artifact's meta-data
 	 * @param sourceArtifactContent the source artifact's content
 	 */
-	public Collection<DerivedArtifactType> deriveArtifacts(BaseArtifactType sourceArtifact,
+	public Collection<BaseArtifactType> deriveArtifacts(BaseArtifactType sourceArtifact,
 			InputStream sourceArtifactContent) throws SrampException;
 
 }


### PR DESCRIPTION
Lots of changes to user defined types and custom artifact derivers. Users 
can now contribute their own derivers that will kick in when user
certain user defined artifacts are added to the repo.  This alows users
to create logical user-defined artifact models, complete with derive
content.
