### PR TITLE
(sramp-151) Fixed a bug with multiple installed ontologies

### DIFF
--- a/s-ramp-common/src/main/java/org/overlord/sramp/common/ontology/InvalidClassifiedByException.java
+++ b/s-ramp-common/src/main/java/org/overlord/sramp/common/ontology/InvalidClassifiedByException.java
@@ -38,7 +38,7 @@ public class InvalidClassifiedByException extends SrampUserException {
      * @param classifiedBy
      */
     public InvalidClassifiedByException(String classifiedBy) {
-        super("Invalid classified-by (it is either an invalid URI or it is not defined by an S-RAMP ontology: " + classifiedBy);
+        super("Invalid classified-by (it is either an invalid URI or it is not defined by an S-RAMP ontology): " + classifiedBy);
     }
 
 }

--- a/s-ramp-repository-jcr/src/main/java/org/overlord/sramp/repository/jcr/JCRPersistence.java
+++ b/s-ramp-repository-jcr/src/main/java/org/overlord/sramp/repository/jcr/JCRPersistence.java
@@ -24,7 +24,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -614,12 +613,11 @@ public class JCRPersistence implements PersistenceManager, DerivedArtifacts, Cla
 		List<SrampOntology> ontologies = getOntologies();
 		for (SrampOntology ontology : ontologies) {
 			Class sclass = ontology.findClass(classification);
-			if (sclass == null) {
-	            throw new InvalidClassifiedByException(classification.toString());
+			if (sclass != null) {
+	            return sclass.normalize();
 			}
-			return sclass.normalize();
 		}
-		return Collections.emptySet();
+        throw new InvalidClassifiedByException(classification.toString());
 	}
 
 	/**


### PR DESCRIPTION
Bug fix: S-RAMP 151.  Multiple ontologies could cause adding a
classification to fail (it was failing if the classifier couldn't be
found in the first ontology it checked).
