### PR TITLE
Disable artifact JCR logging that I accidentally turned on

### DIFF
--- a/s-ramp-repository-jcr/src/main/java/org/overlord/sramp/repository/jcr/JCRPersistence.java
+++ b/s-ramp-repository-jcr/src/main/java/org/overlord/sramp/repository/jcr/JCRPersistence.java
@@ -181,9 +181,9 @@ public class JCRPersistence extends AbstractJCRManager implements PersistenceMan
 			}
 
 			// If debug is enabled, print the artifact graph
-//			if (log.isDebugEnabled()) {
+			if (log.isDebugEnabled()) {
 				printArtifactGraph(metaData.getUuid(), artifactType);
-//			}
+			}
 
 			// Create the S-RAMP Artifact object from the JCR node
 			return JCRNodeToArtifactFactory.createArtifact(session, artifactNode, artifactType);


### PR DESCRIPTION
A previous commit accidentally enabled some JCR logging.
