### PR TITLE
SRAMP-206 Used ModeShape's BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
     <commons.codec.version>1.5</commons.codec.version>
     <jline.version>2.9</jline.version>
     <joda-time.version>2.1</joda-time.version>
-    <tika-core.version>1.2</tika-core.version> <!-- inline with version used by modeshape -->
+    <tika-core.version>1.3</tika-core.version> <!-- inline with version used by modeshape -->
   </properties>
 
   <build>
@@ -292,6 +292,17 @@
         <groupId>org.apache.tika</groupId>
         <artifactId>tika-core</artifactId>
         <version>${tika-core.version}</version>
+      </dependency>
+      <!-- Import the ModeShape BOM for embedded usage. This adds to the "dependenciesManagement" section
+               defaults for all of the modules we might need, but we still have to include in the 
+               "dependencies" section the modules we DO need. The benefit is that we don't have to
+               specify the versions of any of those modules.-->
+      <dependency>
+        <groupId>org.modeshape.bom</groupId>
+        <artifactId>modeshape-bom-embedded</artifactId>
+        <version>${org.modeshape.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/s-ramp-repository-jcr/modeshape/pom.xml
+++ b/s-ramp-repository-jcr/modeshape/pom.xml
@@ -20,13 +20,11 @@
     <dependency>
       <groupId>javax.jcr</groupId>
       <artifactId>jcr</artifactId>
-      <version>2.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.modeshape</groupId>
       <artifactId>modeshape-jcr-api</artifactId>
-      <version>${org.modeshape.version}</version>
       <scope>provided</scope>
     </dependency>
    
@@ -34,13 +32,11 @@
     <dependency>
       <groupId>org.modeshape</groupId>
       <artifactId>modeshape-common</artifactId>
-      <version>${org.modeshape.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.modeshape</groupId>
       <artifactId>modeshape-jcr</artifactId>
-      <version>${org.modeshape.version}</version>
       <scope>provided</scope>
     </dependency>
 		<!-- Common libraries -->


### PR DESCRIPTION
This change slightly simplifies the dependencies but more importantly ensures a consistent set of versions as used by ModeShape. The BOM also excludes whatever transitive dependencies are not needed.
