### PR TITLE
(sramp 209) Use JDBC cache store in s-ramp (eap 6.1)

### DIFF
--- a/s-ramp-installer/src/main/resources/build.xml
+++ b/s-ramp-installer/src/main/resources/build.xml
@@ -38,6 +38,7 @@
     <property name="s-ramp.appserver.zip" location="jboss-eap-6.1.0.zip" />
     <property name="s-ramp.modeshape-distribution.zip.path" location="modeshape-3.2.0.Final-jbosseap-61-dist.zip" />
     <property name="s-ramp.appserver.module.path" location="${s-ramp.appserver.dir}/modules/system/layers/soa" />
+    <property name="s-ramp.appserver.base-module.path" location="${s-ramp.appserver.dir}/modules/system/layers/base" />
   </target>
 
   <!-- Configure properties specific to JBoss AS 7.1.1.Final -->
@@ -45,6 +46,7 @@
     <property name="s-ramp.appserver.zip" location="jboss-as-7.1.1.Final.zip" />
     <property name="s-ramp.modeshape-distribution.zip.path" location="modeshape-distribution-3.1.3.Final-jbossas-71-dist.zip" />
     <property name="s-ramp.appserver.module.path" location="${s-ramp.appserver.dir}/modules" />
+    <property name="s-ramp.appserver.base-module.path" location="${s-ramp.appserver.dir}/modules" />
   </target>
 
   <!-- Configure the properties that will drive the installer -->
@@ -118,6 +120,8 @@
     </delete>
     <copy file="updates/modeshape-module-${appserver.id}.xml" 
           tofile="${s-ramp.appserver.module.path}/org/modeshape/main/module.xml" overwrite="true" />
+    <copy file="updates/infinispan-module-${appserver.id}.xml" 
+          tofile="${s-ramp.appserver.base-module.path}/org/infinispan/main/module.xml" overwrite="true" />
 
     <echo>-----------------------------------</echo>
     <echo>Configuring Modeshape Service</echo>
@@ -136,6 +140,7 @@
 
   <!-- Configure JBoss EAP 6.1 -->
   <target name="config-jboss-eap-6.1" depends="config-jboss-common" if="jboss-eap-6.1">
+    <copy file="updates/sramp-ds.xml" todir="${s-ramp.appserver.deploy.dir}" overwrite="true" />
   </target>
 
   <!-- Configure JBoss AS 7.1.1.Final -->

--- a/s-ramp-installer/src/main/resources/updates/infinispan-module-jboss-as-7.1.1.Final.xml
+++ b/s-ramp-installer/src/main/resources/updates/infinispan-module-jboss-as-7.1.1.Final.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<module xmlns="urn:jboss:module:1.1" name="org.infinispan">
+    <resources>
+        <resource-root path="infinispan-core-5.1.2.FINAL.jar"/>
+        <!--
+            The following artifacts and paths are hacks necessary for AS 7.1.1 and ISPN 5.1.x, which need to be able to access
+            classes from the ModeShape module.
+        -->
+        <resource-root path="modeshape-schematic-3.1.3.Final.jar" />
+        <resource-root path="classes" />
+    </resources>
+
+    <dependencies>
+        <module name="org.infinispan.cachestore.jdbc"/>
+        <module name="javax.api"/>
+        <module name="javax.transaction.api"/>
+        <module name="javax.xml.bind.api"/>
+        <module name="net.jcip"/>
+        <module name="org.apache.xerces" services="import"/>
+        <module name="org.jboss.jandex"/>
+        <module name="org.jboss.logging"/>
+        <module name="org.jboss.marshalling"/>
+        <module name="org.jboss.marshalling.river" services="import"/>
+        <module name="org.jgroups"/>
+    </dependencies>
+</module>

--- a/s-ramp-installer/src/main/resources/updates/infinispan-module-jboss-eap-6.1.xml
+++ b/s-ramp-installer/src/main/resources/updates/infinispan-module-jboss-eap-6.1.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<module xmlns="urn:jboss:module:1.1" name="org.infinispan">
+
+    <properties>
+        <property name="jboss.api" value="unsupported"/>
+    </properties>
+
+    <resources>
+        <resource-root path="infinispan-core-5.2.6.Final-redhat-1.jar"/>
+        <!-- Insert resources here -->
+    </resources>
+
+    <dependencies>
+        <module name="org.infinispan.cachestore.jdbc"/>
+        <module name="javax.api"/>
+        <module name="javax.transaction.api"/>
+        <module name="net.jcip"/>
+        <module name="org.jboss.jandex"/>
+        <module name="org.jboss.logging"/>
+        <module name="org.jboss.marshalling"/>
+        <module name="org.jboss.marshalling.river"/>
+        <module name="org.jboss.staxmapper"/>
+        <module name="org.jgroups"/>
+        <module name="sun.jdk"/>
+    </dependencies>
+</module>

--- a/s-ramp-installer/src/main/resources/updates/sramp-ds.xml
+++ b/s-ramp-installer/src/main/resources/updates/sramp-ds.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<datasources>
+  <datasource jndi-name="java:jboss/datasources/srampDS" pool-name="srampDS" enabled="true"
+    use-java-context="true">
+    <connection-url>jdbc:h2:${jboss.server.data.dir}${/}h2${/}sramp;mvcc=true</connection-url>
+    <driver>h2</driver>
+    <security>
+      <user-name>sa</user-name>
+      <password>sa</password>
+    </security>
+  </datasource>
+</datasources>

--- a/s-ramp-installer/src/main/resources/updates/xslt/configureModeshape-jboss-eap-6.1.xslt
+++ b/s-ramp-installer/src/main/resources/updates/xslt/configureModeshape-jboss-eap-6.1.xslt
@@ -32,7 +32,8 @@
             <cache-container name="modeshape">
                 <local-cache name="sramp">
                     <transaction mode="NON_XA"/>
-                    <file-store relative-to="jboss.server.data.dir" path="modeshape/store/sramp" passivation="false" purge="false"/>
+                    <locking isolation="NONE" />
+                    <mixed-keyed-jdbc-store datasource="java:jboss/datasources/srampDS" />
                 </local-cache>
             </cache-container>
         </subsystem>


### PR DESCRIPTION
Updated the installer to configure EAP modeshape/infini to be h2 db
based rather than file based.

https://issues.jboss.org/browse/SRAMP-209
