### PR TITLE
(sramp-211) Zip expansion in the CLI

### DIFF
--- a/s-ramp-shell/pom.xml
+++ b/s-ramp-shell/pom.xml
@@ -23,6 +23,21 @@
       <artifactId>s-ramp-shell-api</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.overlord.sramp</groupId>
+      <artifactId>s-ramp-integration-java</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.overlord.sramp</groupId>
+      <artifactId>s-ramp-integration-switchyard</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.overlord.sramp</groupId>
+      <artifactId>s-ramp-integration-kie</artifactId>
+      <version>${project.version}</version>
+    </dependency>
 
     <!-- Third party libraries -->
     <dependency>


### PR DESCRIPTION
Added support for zip expansion in the CLI.  It works the same way as the UI and the Maven Wagon now.  ZIPs and JARs will now be expanded client-side when appropriate.

https://issues.jboss.org/browse/SRAMP-211
