### PR TITLE
(sramp-226) Wagon doesn't refresh artifact meta-data prior to pushing changes to server

### DIFF
--- a/s-ramp-wagon/src/main/java/org/overlord/sramp/wagon/SrampWagon.java
+++ b/s-ramp-wagon/src/main/java/org/overlord/sramp/wagon/SrampWagon.java
@@ -383,7 +383,8 @@ public class SrampWagon extends StreamWagon {
             Thread.currentThread().setContextClassLoader(SrampWagon.class.getClassLoader());
             try {
     			SrampArchiveEntry entry = this.archive.getEntry(artyPath);
-    			BaseArtifactType metaData = entry.getMetaData();
+    			// Re-fetch the artifact meta-data in case it changed on the server since we uploaded it.
+    			BaseArtifactType metaData = client.getArtifactMetaData(entry.getMetaData().getUuid());
     			SrampModelUtils.setCustomProperty(metaData, hashPropName, hashValue);
     			this.archive.updateEntry(entry, null);
 


### PR DESCRIPTION
The wagon will now refresh the meta-data for an artifact from the server
prior to updating it with hash values.  This prevents the wagon from
clobbering changes made to the artifact on the server.

https://issues.jboss.org/browse/SRAMP-226
