### PR TITLE
Place demo assembly into its own module; SRAMP-261

### DIFF
--- a/s-ramp-demos/pom.xml
+++ b/s-ramp-demos/pom.xml
@@ -17,13 +17,6 @@
   <name>S-RAMP Demos</name>
   <packaging>pom</packaging>
 
-  <dependencies>
-    <dependency>
-      <groupId>commons-logging</groupId>
-      <artifactId>commons-logging</artifactId>
-    </dependency>
-  </dependencies>
-
   <repositories>
     <repository>
       <id>jboss-public-repository-group</id>
@@ -41,41 +34,13 @@
     </repository>
   </repositories>
 
-  <build>
-    <plugins>
-      <plugin>
-        <artifactId>maven-assembly-plugin</artifactId>
-	<inherited>false</inherited>
-        <executions>
-          <execution>
-            <id>make-dist</id>
-            <phase>package</phase>
-            <goals>
-              <goal>single</goal>
-            </goals>
-            <configuration>
-              <finalName>s-ramp-demos-${project.version}</finalName>
-              <attach>true</attach>
-              <descriptors>
-                <descriptor>src/main/assembly/dist.xml</descriptor>
-              </descriptors>
-              <tarLongFileMode>gnu</tarLongFileMode>
-              <appendAssemblyId>false</appendAssemblyId>
-              <archiverConfig>
-                <defaultDirectoryMode>0755</defaultDirectoryMode>
-              </archiverConfig>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
-
   <profiles>
     <profile>
       <id>with-demos</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!srampExcludeDemos</name>
+        </property>
       </activation>
 
       <modules>
@@ -92,6 +57,16 @@
         <module>s-ramp-demos-shell-command</module>
         <module>s-ramp-demos-switchyard</module>
         <module>s-ramp-demos-switchyard-multiapp</module>
+      </modules>
+    </profile>
+    <profile>
+      <activation>
+        <file>
+          <exists>s-ramp-demos-assembly</exists>
+        </file>
+      </activation>
+      <modules>
+        <module>s-ramp-demos-assembly</module>
       </modules>
     </profile>
   </profiles>

--- a/s-ramp-demos/s-ramp-demos-assembly/pom.xml
+++ b/s-ramp-demos/s-ramp-demos-assembly/pom.xml
@@ -1,0 +1,48 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <!-- /* * Copyright 2013 JBoss Inc * * Licensed under the Apache License, Version 2.0 (the "License"); * you 
+    may not use this file except in compliance with the License. * You may obtain a copy of the License at * * http://www.apache.org/licenses/LICENSE-2.0 
+    * * Unless required by applicable law or agreed to in writing, software * distributed under the License is distributed 
+    on an "AS IS" BASIS, * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. * See the License 
+    for the specific language governing permissions and * limitations under the License. */ -->
+  <modelVersion>4.0.0</modelVersion>
+  <parent> 
+    <groupId>org.overlord.sramp.demos</groupId>
+    <artifactId>s-ramp-demos</artifactId>
+    <version>0.4.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <artifactId>s-ramp-demos-assembly</artifactId>
+  <name>S-RAMP Demos Assembly</name>
+  <packaging>pom</packaging>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+	<inherited>false</inherited>
+        <executions>
+          <execution>
+            <id>make-dist</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <configuration>
+              <finalName>s-ramp-demos-${project.version}</finalName>
+              <attach>true</attach>
+              <descriptors>
+                <descriptor>src/main/assembly/dist.xml</descriptor>
+              </descriptors>
+              <tarLongFileMode>gnu</tarLongFileMode>
+              <appendAssemblyId>false</appendAssemblyId>
+              <archiverConfig>
+                <defaultDirectoryMode>0755</defaultDirectoryMode>
+              </archiverConfig>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/s-ramp-demos/s-ramp-demos-assembly/src/main/assembly/dist.xml
+++ b/s-ramp-demos/s-ramp-demos-assembly/src/main/assembly/dist.xml
@@ -10,7 +10,7 @@
     <fileSets>
         <!-- The S-RAMP demos -->
         <fileSet>
-            <directory>.</directory>
+            <directory>..</directory>
             <outputDirectory></outputDirectory>
             <useDefaultExcludes>true</useDefaultExcludes>
             <excludes>
@@ -20,6 +20,7 @@
                 <exclude>**/.gitignore</exclude>
                 <exclude>**/target/**</exclude>
                 <exclude>src/**</exclude>
+                <exclude>s-ramp-demos-assembly/**</exclude>
             </excludes>
             <directoryMode>0755</directoryMode>
             <fileMode>0755</fileMode>


### PR DESCRIPTION
Fix for SRAMP-261.

Assembly GAV is now org.overlord.sramp.demos:s-ramp-demos-assembly:version
