### PR TITLE
SRAMP-408 Tab completion no longer works in s-ramp CLI. Set alias false

### DIFF
--- a/s-ramp-shell/src/main/java/org/overlord/sramp/shell/InteractiveShellCommandReader.java
+++ b/s-ramp-shell/src/main/java/org/overlord/sramp/shell/InteractiveShellCommandReader.java
@@ -57,7 +57,7 @@ public class InteractiveShellCommandReader extends AbstractShellCommandReader im
 	@Override
 	public void open() throws IOException {
         Settings settings = Settings.getInstance();
-        settings.setAliasEnabled(true);
+        settings.setAliasEnabled(false);
         // settings.setAliasFile(new File("al"));
         settings.setEnablePipelineAndRedirectionParser(false);
         settings.setLogging(true);


### PR DESCRIPTION
https://issues.jboss.org/browse/SRAMP-408

Set alias false to fix an error when clicking tab button 
