### PR TITLE
Align commons.beanutils version across projects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,7 @@
     <s-ramp-wiki.version>0.4.0.Final</s-ramp-wiki.version>
     <overlord-commons.version>2.0.1-SNAPSHOT</overlord-commons.version>
     <log4j.version>1.2.16</log4j.version>
+    <commons.beanutils.version>1.8.2</commons.beanutils.version>
     <commons.lang3.version>3.1</commons.lang3.version>
     <commons.compress.version>1.4.1</commons.compress.version>
     <commons.logging.version>1.1.1</commons.logging.version>
@@ -658,7 +659,7 @@
       <dependency>
         <groupId>commons-beanutils</groupId>
         <artifactId>commons-beanutils-core</artifactId>
-        <version>1.8.0</version>
+        <version>${commons.beanutils.version}</version>
       </dependency>
       <dependency>
         <groupId>log4j</groupId>


### PR DESCRIPTION
Small patch to align the common.beanutils version across projects.
