### PR TITLE
SRAMP-449 Ontologies Page: download icon not being pulled fully right

### DIFF
--- a/s-ramp-ui/s-ramp-ui-war/src/main/webapp/css/s-ramp-ui.css
+++ b/s-ramp-ui/s-ramp-ui-war/src/main/webapp/css/s-ramp-ui.css
@@ -746,3 +746,7 @@ ul.ontology-selector {
 #ontologies table .active a {
   color: white !important;
 }
+
+td .icon{
+	width:1%;
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/SRAMP-449
