### PR TITLE
SRAMP-544 SNAPSHOT artifacts can no longer be pulled from S-RAMP

### DIFF
--- a/s-ramp-server/src/main/java/org/overlord/sramp/server/mvn/services/MavenMetaDataBuilder.java
+++ b/s-ramp-server/src/main/java/org/overlord/sramp/server/mvn/services/MavenMetaDataBuilder.java
@@ -201,7 +201,7 @@ public class MavenMetaDataBuilder {
                             else{
                                 versionParsed=version;
                             }
-                            if(fileName.startsWith(artifactId + "-" + versionParsed)){ //$NON-NLS-1$
+                            if (!fileName.contains(version) && fileName.startsWith(artifactId + "-" + versionParsed)) { //$NON-NLS-1$
                                 String without_extension = fileName.substring(0, fileName.lastIndexOf(".")); //$NON-NLS-1$
                                 if (StringUtils.countMatches(without_extension, "-") >= 2) { //$NON-NLS-1$
                                     int versionIdx = without_extension.indexOf(versionParsed);

--- a/s-ramp-server/src/main/java/org/overlord/sramp/server/mvn/services/MavenRepositoryService.java
+++ b/s-ramp-server/src/main/java/org/overlord/sramp/server/mvn/services/MavenRepositoryService.java
@@ -205,7 +205,7 @@ public class MavenRepositoryService extends HttpServlet {
 
         try {
             QueryManager queryManager = QueryManagerFactory.newInstance();
-            SrampQuery srampQuery = queryManager.createQuery(queryBuilder.toString(), "lastModifiedTimestamp", false); //$NON-NLS-1$
+            SrampQuery srampQuery = queryManager.createQuery(queryBuilder.toString(), "createdTimestamp", false); //$NON-NLS-1$
 
             for (Object parameter : parameters) {
                 if (parameter instanceof String) {
@@ -257,8 +257,6 @@ public class MavenRepositoryService extends HttpServlet {
         if (StringUtils.isNotBlank(metadata.getSnapshotId())) {
             criteria.add("@maven.snapshot.id = ?"); //$NON-NLS-1$
             parameters.add(metadata.getSnapshotId());
-        } else {
-            criteria.add("xp2:not(@maven.snapshot.id)"); //$NON-NLS-1$
         }
 
         ArtifactSet artifactSet = null;

--- a/s-ramp-wagon/src/main/java/org/overlord/sramp/wagon/SrampWagon.java
+++ b/s-ramp-wagon/src/main/java/org/overlord/sramp/wagon/SrampWagon.java
@@ -93,7 +93,7 @@ public class SrampWagon extends StreamWagon {
 	private transient SrampArchive archive;
 	private transient SrampAtomApiClient client;
 
-    private boolean allowSnapshot;
+    private final boolean allowSnapshot;
 
 	/**
 	 * Constructor.
@@ -551,7 +551,7 @@ public class SrampWagon extends StreamWagon {
 	    if (allowSnapshot || !gavInfo.isSnapshot()) {
     		logger.info(Messages.i18n.format("UPLOADING_TO_SRAMP", resource.getName())); //$NON-NLS-1$
     		firePutInitiated(resource, source);
-    
+
     		firePutStarted(resource, source);
     		if (resource.getName().contains("maven-metadata.xml")) { //$NON-NLS-1$
     			logger.info(Messages.i18n.format("SKIPPING_ARTY", resource.getName())); //$NON-NLS-1$
@@ -836,9 +836,8 @@ public class SrampWagon extends StreamWagon {
             params.add(gavInfo.getClassifier());
         }
         if (StringUtils.isNotBlank(gavInfo.getSnapshotId())) {
-            return null;
-        } else {
-            criteria.add("xp2:not(@maven.snapshot.id)"); //$NON-NLS-1$
+            criteria.add("@maven.snapshot.id = ?"); //$NON-NLS-1$
+            params.add(gavInfo.getSnapshotId());
         }
 
         if (criteria.size() > 0) {
@@ -856,7 +855,7 @@ public class SrampWagon extends StreamWagon {
             }
         }
 
-		QueryResultSet rset = clientQuery.count(100).query();
+        QueryResultSet rset = clientQuery.count(100).orderBy("createdTimestamp").descending().query();//$NON-NLS-1$
 		if (rset.size() > 0) {
 			for (ArtifactSummary summary : rset) {
 				String uuid = summary.getUuid();


### PR DESCRIPTION
https://issues.jboss.org/browse/SRAMP-544

Instructions to test:
If you want to test the fix it could be good to check the Sramp pulling using wagon and the Maven Repository Service:
Steps:

```
Deploy s-ramp
Go here: s-ramp/s-ramp-demos/s-ramp-demos-webapp-multimodule
cd artifacts
mvn clean deploy -Pdemo
cd ..
cd web
Remove the s-ramp-demos-webapp-multimodule-artifacs content of your maven local repository to force maven do download from s-ramp.
Test the pulling mechanism. It could be using:

    Wagon --> mvn clean install -Pdemo
    Maven Repository Service --> Include the maven repository and mvn clean install:

      <repositories>
        <repository>
          <id>local-sramp-maven-repo</id>
          <name>S-RAMP Releases Repository</name>
          <url>http://localhost:8080/s-ramp-server/maven/repository</url>
        </repository>
      </repositories>
```
