### PR TITLE
Docker profile added to test latest in docker

### DIFF
--- a/distro/assembly/pom.xml
+++ b/distro/assembly/pom.xml
@@ -225,6 +225,7 @@
   </dependencies>
 
   <build>
+    <finalName>artificer-${project.version}</finalName>
     <plugins>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
@@ -244,7 +245,7 @@
               <goal>single</goal>
             </goals>
             <configuration>
-              <finalName>artificer-${project.version}</finalName>
+
               <attach>true</attach>
               <descriptors>
                 <descriptor>src/main/assembly/dist.xml</descriptor>
@@ -300,6 +301,40 @@
         </plugins>
       </build>
     </profile>
+
+    <profile>
+      <id>docker</id>
+      <build>
+        <finalName>artificer</finalName>
+        <plugins>
+          <plugin>
+            <groupId>com.spotify</groupId>
+            <artifactId>docker-maven-plugin</artifactId>
+            <version>0.1.1</version>
+            <executions>
+              <execution>
+                <phase>package</phase>
+                <goals>
+                  <goal>build</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <imageName>artificer:${project.version}</imageName>
+              <dockerDirectory>${project.basedir}/src/main/docker</dockerDirectory>
+              <resources>
+                <resource>
+                  <targetPath>/artificer.zip</targetPath>
+                  <directory>${project.build.directory}</directory>
+                  <include>artificer.zip</include>
+                </resource>
+              </resources>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
   </profiles>
   
 </project>

--- a/distro/assembly/src/main/docker/Dockerfile
+++ b/distro/assembly/src/main/docker/Dockerfile
@@ -1,0 +1,23 @@
+FROM jboss/wildfly
+
+RUN $JBOSS_HOME/bin/add-user.sh admin artificer1! --silent
+
+EXPOSE 8787
+
+# Ant installed here to invalidate as fewer layers on rebuild and beeing able to reuse this layer
+RUN cd /tmp \
+    && curl http://mirrors.ukfast.co.uk/sites/ftp.apache.org/ant/binaries/apache-ant-1.9.4-bin.tar.gz -o apache-ant-1.9.4-bin.tar.gz \
+    && bsdtar -xf apache-ant-1.9.4-bin.tar.gz \
+    && rm apache-ant-1.9.4-bin.tar.gz
+
+CMD ["/opt/jboss/wildfly/bin/standalone.sh", "-b", "0.0.0.0", "-bmanagement", "0.0.0.0", "-c", "standalone-full.xml", "--debug"]
+
+# These 2 steps are latest as to invalidate as fewer layers as possible with each build
+COPY artificer.zip /tmp/
+RUN cd /tmp \
+    && bsdtar -xf /tmp/artificer.zip \
+    && /tmp/apache-ant-1.9.4/bin/ant -f /tmp/artificer/build.xml -Ds-ramp-distro.choices.platform=1 -Ds-ramp-distro.choices.platform.jboss-wildfly-8.path=$JBOSS_HOME -Dejb-jms.password=artificer1! \
+    && cp /tmp/artificer/artificer-realm.json $JBOSS_HOME \
+    && rm -rf /tmp/artificer \
+    && echo 'JAVA_OPTS="$JAVA_OPTS -Djboss.bind.address=0.0.0.0 -Djboss.bind.address.management=0.0.0.0 -Dkeycloak.import=$JBOSS_HOME/artificer-realm.json"' >> $JBOSS_HOME/bin/standalone.conf \
+    && sed -i -e "s/Xms64m/Xms1G/g" $JBOSS_HOME/bin/standalone.conf -e "s/Xmx512m/Xmx1G/g" -e "s/MaxPermSize=256m/MaxPermSize=384m/g" $JBOSS_HOME/bin/standalone.conf


### PR DESCRIPTION
run mvn clean install -P docker. You'll have a docker image that can be run with:

docker run -it --rm -p 8080:8080 -p 9990:9990 artificer:1.0.0-SNAPSHOT
This is using this plugin, and can be enhanced, worked with: https://github.com/spotify/docker-maven-plugin 
I've tried different plugins, and this is the one that best fits this needs.

Added admin user so we can log into wildfly console and add deployments if needed. (artificer1! is password)
Added debug options and debug port in 8787 so docker can be used as development environment

Also added json schema import and update memory settings as recommended.

If the use of the image in development is good, then a final image can be made for release 1.0.0 although I recommend revisit the install process :-D
